### PR TITLE
Fix issues in SCons interpreter for CMake conversion

### DIFF
--- a/tools/cmakeconverter/SCons/Script/__init__.py
+++ b/tools/cmakeconverter/SCons/Script/__init__.py
@@ -1,0 +1,34 @@
+"""Mock SCons.Script module"""
+from interpreter.variables import Variables, EnumVariable, BoolVariable, PathVariable, ListVariable
+from interpreter.builders import Action, Builder, Program, StaticLibrary, SharedLibrary, Object
+
+# Global variables
+ARGUMENTS = {}
+COMMAND_LINE_TARGETS = []
+BUILD_TARGETS = []
+DEFAULT_TARGETS = []
+
+# Functions
+def GetOption(name: str):
+    """Get a command-line option"""
+    return None
+
+def SetOption(name: str, value):
+    """Set a command-line option"""
+    pass
+
+def AddOption(*args, **kwargs):
+    """Add a command-line option"""
+    pass
+
+def GetBuildFailures():
+    """Get list of build failures"""
+    return []
+
+def Progress(*args, **kwargs):
+    """Set up progress display"""
+    pass
+
+def Exit(msg=None):
+    """Exit SCons with optional message"""
+    pass

--- a/tools/cmakeconverter/SCons/Util/__init__.py
+++ b/tools/cmakeconverter/SCons/Util/__init__.py
@@ -1,0 +1,65 @@
+"""Mock SCons.Util package"""
+import os
+import sys
+import shutil
+
+def WhereIs(program, path=None, pathext=None, reject=[]):
+    """Find an executable in the system path"""
+    if path is None:
+        path = os.environ.get('PATH', '').split(os.pathsep)
+    
+    if pathext is None:
+        pathext = ['']
+        if sys.platform == 'win32':
+            pathext.extend(os.environ.get('PATHEXT', '').split(os.pathsep))
+    
+    for dir in path:
+        for ext in pathext:
+            full_path = os.path.join(dir, program + ext)
+            if os.path.isfile(full_path) and full_path not in reject:
+                return full_path
+    
+    # Fallback to shutil.which
+    return shutil.which(program)
+
+def is_String(obj):
+    """Check if object is a string"""
+    return isinstance(obj, str)
+
+def is_List(obj):
+    """Check if object is a list"""
+    return isinstance(obj, list)
+
+def is_Dict(obj):
+    """Check if object is a dictionary"""
+    return isinstance(obj, dict)
+
+def flatten(sequence):
+    """Flatten a sequence"""
+    result = []
+    for item in sequence:
+        if isinstance(item, (list, tuple)):
+            result.extend(flatten(item))
+        else:
+            result.append(item)
+    return result
+
+def to_String(obj):
+    """Convert object to string"""
+    return str(obj)
+
+def to_List(obj):
+    """Convert object to list"""
+    if isinstance(obj, list):
+        return obj
+    elif isinstance(obj, tuple):
+        return list(obj)
+    else:
+        return [obj]
+
+def to_Dict(obj):
+    """Convert object to dictionary"""
+    if isinstance(obj, dict):
+        return obj
+    else:
+        raise TypeError(f"Cannot convert {type(obj)} to dict")

--- a/tools/cmakeconverter/SCons/Variables/BoolVariable.py
+++ b/tools/cmakeconverter/SCons/Variables/BoolVariable.py
@@ -1,0 +1,15 @@
+"""Mock SCons.Variables.BoolVariable module"""
+
+def _text2bool(val):
+    """Convert text string to boolean value"""
+    val = val.lower()
+    if val in ('1', 'true', 't', 'yes', 'y', 'on'):
+        return True
+    elif val in ('0', 'false', 'f', 'no', 'n', 'off'):
+        return False
+    raise ValueError(f"Invalid boolean value: {val}")
+
+def BoolVariable(key, help, default):
+    """Create a boolean SCons variable"""
+    from interpreter.variables import BoolVariable as InterpreterBoolVariable
+    return InterpreterBoolVariable(key, help, default)

--- a/tools/cmakeconverter/SCons/Variables/__init__.py
+++ b/tools/cmakeconverter/SCons/Variables/__init__.py
@@ -1,0 +1,4 @@
+"""Mock SCons.Variables package"""
+from interpreter.variables import Variables, EnumVariable, BoolVariable, PathVariable, ListVariable
+
+__all__ = ['Variables', 'EnumVariable', 'BoolVariable', 'PathVariable', 'ListVariable']

--- a/tools/cmakeconverter/SCons/__init__.py
+++ b/tools/cmakeconverter/SCons/__init__.py
@@ -1,0 +1,2 @@
+"""Mock SCons package"""
+from mock_scons import __version__

--- a/tools/cmakeconverter/cmake_generator.py
+++ b/tools/cmakeconverter/cmake_generator.py
@@ -1,0 +1,319 @@
+"""CMake project generator for Godot"""
+from typing import Any, Dict, List, Optional, Set
+import os
+import textwrap
+
+class CMakeTarget:
+    """Represents a CMake target (executable, library, etc.)"""
+    def __init__(self, name: str, target_type: str):
+        self.name = name
+        self.type = target_type  # executable, library, etc.
+        self.sources: List[str] = []
+        self.include_dirs: Set[str] = set()
+        self.compile_definitions: Set[str] = set()
+        self.compile_options: Set[str] = set()
+        self.link_libraries: Set[str] = set()
+        self.link_options: Set[str] = set()
+        self.dependencies: Set[str] = set()
+
+    def add_sources(self, sources: List[str]):
+        """Add source files to the target"""
+        self.sources.extend(sources)
+
+    def add_include_dirs(self, dirs: List[str]):
+        """Add include directories"""
+        self.include_dirs.update(dirs)
+
+    def add_definitions(self, defs: List[str]):
+        """Add compile definitions"""
+        self.compile_definitions.update(defs)
+
+    def add_compile_options(self, options: List[str]):
+        """Add compile options"""
+        self.compile_options.update(options)
+
+    def add_link_libraries(self, libs: List[str]):
+        """Add libraries to link against"""
+        self.link_libraries.update(libs)
+
+    def add_link_options(self, options: List[str]):
+        """Add linker options"""
+        self.link_options.update(options)
+
+    def add_dependencies(self, deps: List[str]):
+        """Add target dependencies"""
+        self.dependencies.update(deps)
+
+    def generate(self, indent: int = 0) -> str:
+        """Generate CMake code for this target"""
+        ind = " " * indent
+        lines = []
+
+        # Target declaration
+        if self.type == "executable":
+            lines.append(f"{ind}add_executable({self.name}")
+        elif self.type == "shared":
+            lines.append(f"{ind}add_library({self.name} SHARED")
+        elif self.type == "static":
+            lines.append(f"{ind}add_library({self.name} STATIC")
+        else:
+            lines.append(f"{ind}add_library({self.name} {self.type}")
+
+        # Sources
+        if self.sources:
+            lines.append(f"{ind}    {' '.join(sorted(self.sources))}")
+        lines.append(f"{ind})")
+
+        # Include directories
+        if self.include_dirs:
+            lines.append(f"{ind}target_include_directories({self.name} PUBLIC")
+            for inc in sorted(self.include_dirs):
+                lines.append(f"{ind}    {inc}")
+            lines.append(f"{ind})")
+
+        # Compile definitions
+        if self.compile_definitions:
+            lines.append(f"{ind}target_compile_definitions({self.name} PUBLIC")
+            for define in sorted(self.compile_definitions):
+                lines.append(f"{ind}    {define}")
+            lines.append(f"{ind})")
+
+        # Compile options
+        if self.compile_options:
+            lines.append(f"{ind}target_compile_options({self.name} PUBLIC")
+            for opt in sorted(self.compile_options):
+                lines.append(f"{ind}    {opt}")
+            lines.append(f"{ind})")
+
+        # Link libraries
+        if self.link_libraries:
+            lines.append(f"{ind}target_link_libraries({self.name} PUBLIC")
+            for lib in sorted(self.link_libraries):
+                lines.append(f"{ind}    {lib}")
+            lines.append(f"{ind})")
+
+        # Link options
+        if self.link_options:
+            lines.append(f"{ind}target_link_options({self.name} PUBLIC")
+            for opt in sorted(self.link_options):
+                lines.append(f"{ind}    {opt}")
+            lines.append(f"{ind})")
+
+        # Dependencies
+        if self.dependencies:
+            lines.append(f"{ind}add_dependencies({self.name}")
+            for dep in sorted(self.dependencies):
+                lines.append(f"{ind}    {dep}")
+            lines.append(f"{ind})")
+
+        return "\n".join(lines)
+
+class CMakeProject:
+    """Represents a CMake project"""
+    def __init__(self, name: str, version: str = "1.0.0"):
+        self.name = name
+        self.version = version
+        self.minimum_version = "3.16"
+        self.targets: Dict[str, CMakeTarget] = {}
+        self.variables: Dict[str, Any] = {}
+        self.options: Dict[str, Any] = {}
+        self.custom_commands: List[str] = []
+        self.custom_targets: List[str] = []
+        self.includes: List[str] = []
+
+    def add_target(self, name: str, target_type: str) -> CMakeTarget:
+        """Add a new target to the project"""
+        target = CMakeTarget(name, target_type)
+        self.targets[name] = target
+        return target
+
+    def set_variable(self, name: str, value: Any):
+        """Set a CMake variable"""
+        self.variables[name] = value
+
+    def add_option(self, name: str, description: str, default_value: Any):
+        """Add a CMake option"""
+        self.options[name] = {
+            "description": description,
+            "default": default_value
+        }
+
+    def add_custom_command(self, command: str):
+        """Add a custom CMake command"""
+        self.custom_commands.append(command)
+
+    def add_custom_target(self, target: str):
+        """Add a custom CMake target"""
+        self.custom_targets.append(target)
+
+    def add_include(self, path: str):
+        """Add a CMake include directive"""
+        self.includes.append(path)
+
+    def generate(self) -> str:
+        """Generate the complete CMake project"""
+        lines = []
+
+        # Header
+        lines.append(f"cmake_minimum_required(VERSION {self.minimum_version})")
+        lines.append(f"project({self.name} VERSION {self.version})")
+        lines.append("")
+
+        # Options
+        if self.options:
+            lines.append("# Options")
+            for name, opt in self.options.items():
+                lines.append(f'option({name} "{opt["description"]}" {opt["default"]})')
+            lines.append("")
+
+        # Variables
+        if self.variables:
+            lines.append("# Variables")
+            for name, value in self.variables.items():
+                if isinstance(value, (list, tuple, set)):
+                    lines.append(f"set({name}")
+                    for item in value:
+                        lines.append(f"    {item}")
+                    lines.append(")")
+                else:
+                    lines.append(f"set({name} {value})")
+            lines.append("")
+
+        # Includes
+        if self.includes:
+            lines.append("# Includes")
+            for inc in self.includes:
+                lines.append(f"include({inc})")
+            lines.append("")
+
+        # Custom commands
+        if self.custom_commands:
+            lines.append("# Custom commands")
+            for cmd in self.custom_commands:
+                lines.append(cmd)
+            lines.append("")
+
+        # Custom targets
+        if self.custom_targets:
+            lines.append("# Custom targets")
+            for target in self.custom_targets:
+                lines.append(target)
+            lines.append("")
+
+        # Targets
+        if self.targets:
+            lines.append("# Targets")
+            for target in self.targets.values():
+                lines.append(target.generate(indent=0))
+                lines.append("")
+
+        return "\n".join(lines)
+
+class GodotCMakeGenerator:
+    """Generates CMake project from Godot's SCons configuration"""
+    def __init__(self):
+        self.project = CMakeProject("godot")
+        self.platform_defines: Dict[str, List[str]] = {}
+        self.platform_flags: Dict[str, List[str]] = {}
+        self.enabled_modules: Set[str] = set()
+
+    def process_variables(self, variables: Dict[str, Any]):
+        """Process SCons variables into CMake options/variables"""
+        for name, value in variables.items():
+            if isinstance(value, bool):
+                # Convert boolean SCons variables to CMake options
+                self.project.add_option(
+                    name=name.upper(),
+                    description=f"Enable {name}",
+                    default_value="ON" if value else "OFF"
+                )
+            elif isinstance(value, (str, int, float)):
+                # Convert scalar SCons variables to CMake variables
+                self.project.set_variable(name.upper(), value)
+            elif isinstance(value, (list, tuple)):
+                # Convert list SCons variables to CMake list variables
+                self.project.set_variable(name.upper(), ";".join(str(x) for x in value))
+
+    def process_environment(self, env: Dict[str, Any]):
+        """Process SCons environment into CMake configuration"""
+        # Process compiler flags
+        if "CCFLAGS" in env:
+            self.project.set_variable("CMAKE_C_FLAGS", " ".join(env["CCFLAGS"]))
+            self.project.set_variable("CMAKE_CXX_FLAGS", " ".join(env["CCFLAGS"]))
+
+        if "CXXFLAGS" in env:
+            self.project.set_variable("CMAKE_CXX_FLAGS", " ".join(env["CXXFLAGS"]))
+
+        if "LINKFLAGS" in env:
+            self.project.set_variable("CMAKE_EXE_LINKER_FLAGS", " ".join(env["LINKFLAGS"]))
+            self.project.set_variable("CMAKE_SHARED_LINKER_FLAGS", " ".join(env["LINKFLAGS"]))
+
+        # Process include paths
+        if "CPPPATH" in env:
+            includes = [f"${{CMAKE_SOURCE_DIR}}/{path}" for path in env["CPPPATH"]]
+            self.project.set_variable("GODOT_INCLUDE_DIRS", includes)
+
+        # Process defines
+        if "CPPDEFINES" in env:
+            defines = []
+            for define in env["CPPDEFINES"]:
+                if isinstance(define, tuple):
+                    defines.append(f"{define[0]}={define[1]}")
+                else:
+                    defines.append(str(define))
+            self.project.set_variable("GODOT_DEFINES", defines)
+
+    def process_modules(self, modules: List[str]):
+        """Process Godot modules into CMake targets"""
+        for module in modules:
+            target = self.project.add_target(f"godot_{module}", "static")
+            target.add_compile_definitions([f"MODULE_{module.upper()}_ENABLED"])
+            self.enabled_modules.add(module)
+
+    def process_platform(self, platform: str):
+        """Process platform-specific configuration"""
+        if platform in self.platform_defines:
+            self.project.set_variable(
+                f"GODOT_{platform.upper()}_DEFINES",
+                self.platform_defines[platform]
+            )
+
+        if platform in self.platform_flags:
+            self.project.set_variable(
+                f"GODOT_{platform.upper()}_FLAGS",
+                self.platform_flags[platform]
+            )
+
+    def generate(self, output_path: str):
+        """Generate the CMake project files"""
+        # Main CMakeLists.txt
+        cmake_content = self.project.generate()
+        
+        # Write the main CMakeLists.txt
+        os.makedirs(os.path.dirname(output_path), exist_ok=True)
+        with open(output_path, "w") as f:
+            f.write(cmake_content)
+
+        # Generate module CMakeLists.txt files
+        for module in self.enabled_modules:
+            module_path = f"modules/{module}/CMakeLists.txt"
+            module_content = self._generate_module_cmake(module)
+            os.makedirs(os.path.dirname(module_path), exist_ok=True)
+            with open(module_path, "w") as f:
+                f.write(module_content)
+
+    def _generate_module_cmake(self, module: str) -> str:
+        """Generate CMakeLists.txt for a specific module"""
+        lines = []
+        lines.append(f"# CMakeLists.txt for module {module}")
+        lines.append("")
+        lines.append(f"target_sources(godot_{module}")
+        lines.append("    PRIVATE")
+        lines.append("        ${MODULE_SOURCES}")  # Placeholder
+        lines.append(")")
+        lines.append("")
+        lines.append("target_include_directories(godot_{module}")
+        lines.append("    PUBLIC")
+        lines.append("        ${CMAKE_CURRENT_SOURCE_DIR}")
+        lines.append(")")
+        return "\n".join(lines)

--- a/tools/cmakeconverter/converter.py
+++ b/tools/cmakeconverter/converter.py
@@ -1,0 +1,97 @@
+"""Convert Godot's SCons build system to CMake"""
+import os
+import sys
+from typing import Any, Dict, List, Optional
+
+from interpreter import SConsInterpreter, SConsError
+from cmake_generator import GodotCMakeGenerator
+
+class BuildSystemConverter:
+    """Converts SCons build system to CMake"""
+    def __init__(self):
+        self.interpreter = SConsInterpreter()
+        self.cmake_generator = GodotCMakeGenerator()
+        self.scons_vars: Dict[str, Any] = {}
+        self.scons_env: Dict[str, Any] = {}
+        self.platform = ""
+        self.modules: List[str] = []
+
+    def process_scons(self, sconstruct_path: str):
+        """Process the SCons build system"""
+        try:
+            # Add project root to Python path
+            project_root = os.path.dirname(os.path.abspath(sconstruct_path))
+            if project_root not in sys.path:
+                sys.path.insert(0, project_root)
+
+            # Parse SCons configuration
+            self.interpreter.interpret_file(sconstruct_path)
+
+            # Extract variables
+            self.scons_vars = self.interpreter.variables
+            
+            # Get default environment
+            env = self.interpreter.default_env
+            if hasattr(env, 'Dictionary'):
+                self.scons_env = env.Dictionary()
+            else:
+                self.scons_env = {}
+
+            # Get platform
+            self.platform = self.scons_env.get('platform', '')
+
+            # Get modules
+            self.modules = self._detect_modules()
+
+        except SConsError as e:
+            print(f"Error processing SCons: {e}")
+            raise
+
+    def _detect_modules(self) -> List[str]:
+        """Detect available Godot modules"""
+        modules = []
+        modules_path = os.path.join(os.path.dirname(self.interpreter.current_script_dir), "modules")
+        
+        if os.path.exists(modules_path):
+            for item in os.listdir(modules_path):
+                if os.path.isdir(os.path.join(modules_path, item)):
+                    # Check if it's a valid module (has a SCons file)
+                    if os.path.exists(os.path.join(modules_path, item, "SCsub")):
+                        modules.append(item)
+        
+        return modules
+
+    def generate_cmake(self, output_path: str):
+        """Generate CMake project"""
+        try:
+            # Process variables
+            self.cmake_generator.process_variables(self.scons_vars)
+
+            # Process environment
+            self.cmake_generator.process_environment(self.scons_env)
+
+            # Process modules
+            self.cmake_generator.process_modules(self.modules)
+
+            # Process platform
+            if self.platform:
+                self.cmake_generator.process_platform(self.platform)
+
+            # Generate CMake files
+            self.cmake_generator.generate(output_path)
+
+        except Exception as e:
+            print(f"Error generating CMake: {e}")
+            raise
+
+def convert_build_system(sconstruct_path: str, output_path: str):
+    """Convert SCons build system to CMake"""
+    converter = BuildSystemConverter()
+    
+    print("Processing SCons build system...")
+    converter.process_scons(sconstruct_path)
+    
+    print("Generating CMake project...")
+    converter.generate_cmake(output_path)
+    
+    print("Conversion complete!")

--- a/tools/cmakeconverter/core_builders.py
+++ b/tools/cmakeconverter/core_builders.py
@@ -1,0 +1,69 @@
+"""Mock core_builders module"""
+
+def add_module_version_string(env):
+    """Add module version string to environment"""
+    env.module_version_string = ""
+
+def get_version_info(version_string):
+    """Get version info from version string"""
+    return {
+        'major': 4,
+        'minor': 2,
+        'patch': 0,
+        'status': 'stable',
+        'build': '',
+        'year': 2024,
+        'website': 'https://godotengine.org',
+        'docs': 'https://docs.godotengine.org',
+        'string': version_string,
+    }
+
+def Run(env, commands):
+    """Run commands"""
+    pass
+
+def add_source_files(env, sources, files, warn_duplicates=True):
+    """Add source files to list"""
+    if isinstance(files, str):
+        files = [files]
+    sources.extend(files)
+
+def add_library(env, name, sources, **args):
+    """Add library target"""
+    pass
+
+def add_program(env, name, sources, **args):
+    """Add program target"""
+    pass
+
+def add_shared_library(env, name, sources, **args):
+    """Add shared library target"""
+    pass
+
+def add_static_library(env, name, sources, **args):
+    """Add static library target"""
+    pass
+
+def add_thirdparty_library(env, name, thirdparty_dir, thirdparty_sources, thirdparty_env, **args):
+    """Add third-party library target"""
+    pass
+
+def add_thirdparty_sources(env, thirdparty_dir, thirdparty_sources, thirdparty_env, **args):
+    """Add third-party sources"""
+    pass
+
+def detect_modules():
+    """Detect available modules"""
+    return []
+
+def get_doc_classes():
+    """Get documentation classes"""
+    return []
+
+def get_doc_path():
+    """Get documentation path"""
+    return ""
+
+def get_doc_data():
+    """Get documentation data"""
+    return {}

--- a/tools/cmakeconverter/interpreter/__init__.py
+++ b/tools/cmakeconverter/interpreter/__init__.py
@@ -1,0 +1,204 @@
+"""SCons interpreter package"""
+from typing import Any, Dict, List, Optional, Union
+import os
+import sys
+
+from .base import (
+    SConsError, UnsupportedFeatureError, BuildError,
+    EnsureSConsVersion, EnsurePythonVersion,
+    Node, FileNode, DirNode
+)
+from .environment import SConsEnvironment
+from .variables import Variable, EnumVariable, BoolVariable, PathVariable, ListVariable, Variables
+from .builders import Action, Builder, Program, StaticLibrary, SharedLibrary, Object
+from .utils import (
+    WhereIs, is_String, is_List, is_Dict,
+    flatten, to_String, to_List, to_Dict
+)
+
+class SConsInterpreter:
+    """Main SCons interpreter class"""
+    def __init__(self, project_root: Optional[str] = None):
+        self.default_env = SConsEnvironment()
+        self.environments: Dict[str, SConsEnvironment] = {}
+        self.variables: Dict[str, Any] = {}
+        self.targets: Dict[str, Any] = {}
+        self.current_script_dir = ""
+        self.project_root = project_root
+        self._dict = {}
+        
+        if project_root:
+            # Add project root to Python path for imports
+            sys.path.insert(0, project_root)
+            
+        # Initialize basic SCons variables
+        self.variables.update({
+            'ARGUMENTS': {},
+            'COMMAND_LINE_TARGETS': [],
+            'BUILD_DIR': 'build',
+            'ENV': os.environ.copy(),
+        })
+        
+    def Environment(self, **kwargs) -> SConsEnvironment:
+        """Create a new construction environment"""
+        env = SConsEnvironment()
+        
+        # Process tools
+        tools = kwargs.get('tools', ['default'])
+        if tools:
+            env.tools.extend(tools)
+            
+        # Process other variables
+        for key, value in kwargs.items():
+            if key != 'tools':
+                env.variables[key] = value
+                
+        return env
+    
+    def interpret_file(self, filepath: str) -> None:
+        """Interpret a SCons script file"""
+        try:
+            self.current_script_dir = os.path.dirname(filepath)
+            with open(filepath, 'r') as f:
+                content = f.read()
+            
+            # Create a new global namespace for execution
+            opts = Variables()
+            
+            global_dict = {
+                'Environment': self.Environment,
+                'ARGUMENTS': self.variables.get('ARGUMENTS', {}),
+                'COMMAND_LINE_TARGETS': self.variables.get('COMMAND_LINE_TARGETS', []),
+                'DefaultEnvironment': lambda: self.default_env,
+                'Export': self.Export,
+                'Import': self.Import,
+                'SConscript': self.SConscript,
+                'EnsureSConsVersion': EnsureSConsVersion,
+                'EnsurePythonVersion': EnsurePythonVersion,
+                'Variables': lambda *args: opts,  # Return the same instance
+                'EnumVariable': EnumVariable,
+                'BoolVariable': BoolVariable,
+                'PathVariable': PathVariable,
+                'ListVariable': ListVariable,
+                'File': lambda x: FileNode(x),
+                'Dir': lambda x: DirNode(x),
+                'Action': Action,
+                'Builder': Builder,
+                'Program': Program,
+                'StaticLibrary': StaticLibrary,
+                'SharedLibrary': SharedLibrary,
+                'Object': Object,
+                'WhereIs': WhereIs,
+                'Help': lambda x: None,  # We don't need to process help text for CMake
+            }
+            
+            # Execute the SCons script
+            exec(content, global_dict)
+            
+        except Exception as e:
+            import traceback
+            traceback.print_exc()
+            raise SConsError(f"Error interpreting {filepath}: {str(e)}")
+    
+    def Export(self, *args, **kwargs):
+        """Export variables to other SConscript files"""
+        if len(args) == 1 and isinstance(args[0], str):
+            # Export('var1 var2 var3')
+            var_names = args[0].split()
+            for var in var_names:
+                if var in self._dict:
+                    self.variables[f"exported_{var}"] = self._dict[var]
+                elif var in self.variables:
+                    self.variables[f"exported_{var}"] = self.variables[var]
+                else:
+                    # Create an empty export
+                    self.variables[f"exported_{var}"] = None
+        elif len(args) == 1 and isinstance(args[0], dict):
+            # Export({'var1': value1, 'var2': value2})
+            for key, value in args[0].items():
+                self.variables[f"exported_{key}"] = value
+        elif kwargs:
+            # Export(var1=value1, var2=value2)
+            for key, value in kwargs.items():
+                self.variables[f"exported_{key}"] = value
+        else:
+            raise SConsError("Unsupported Export() format")
+    
+    def Import(self, *args):
+        """Import variables from other SConscript files"""
+        if len(args) == 1 and isinstance(args[0], str):
+            # Import('var1 var2 var3')
+            var_names = args[0].split()
+            for var in var_names:
+                exported_var = f"exported_{var}"
+                if exported_var in self.variables:
+                    self.variables[var] = self.variables[exported_var]
+                    self._dict[var] = self.variables[exported_var]
+                else:
+                    # Create an empty import
+                    self.variables[var] = None
+                    self._dict[var] = None
+        else:
+            raise SConsError("Unsupported Import() format")
+    
+    def SConscript(self, scripts, *args, **kwargs):
+        """Process subsidiary SConscript files"""
+        if isinstance(scripts, str):
+            scripts = [scripts]
+        
+        # Get exports from kwargs
+        exports = kwargs.get('exports', [])
+        if isinstance(exports, str):
+            exports = [exports]
+        elif isinstance(exports, dict):
+            exports = list(exports.keys())
+            
+        # Export variables
+        for var in exports:
+            if var in self.variables:
+                self.variables[f"exported_{var}"] = self.variables[var]
+            elif var in self._dict:
+                self.variables[f"exported_{var}"] = self._dict[var]
+            else:
+                self.variables[f"exported_{var}"] = None
+        
+        for script in scripts:
+            script_path = os.path.join(self.current_script_dir, script)
+            if not os.path.exists(script_path):
+                raise SConsError(f"SConscript file not found: {script_path}")
+            
+            # Create a new global namespace for the script
+            opts = Variables()
+            
+            global_dict = {
+                'env': self.default_env,
+                'Environment': self.Environment,
+                'ARGUMENTS': self.variables.get('ARGUMENTS', {}),
+                'COMMAND_LINE_TARGETS': self.variables.get('COMMAND_LINE_TARGETS', []),
+                'DefaultEnvironment': lambda: self.default_env,
+                'Export': self.Export,
+                'Import': self.Import,
+                'SConscript': self.SConscript,
+                'EnsureSConsVersion': EnsureSConsVersion,
+                'EnsurePythonVersion': EnsurePythonVersion,
+                'Variables': lambda *args: opts,  # Return the same instance
+                'EnumVariable': EnumVariable,
+                'BoolVariable': BoolVariable,
+                'PathVariable': PathVariable,
+                'ListVariable': ListVariable,
+                'File': lambda x: FileNode(x),
+                'Dir': lambda x: DirNode(x),
+                'Action': Action,
+                'Builder': Builder,
+                'Program': Program,
+                'StaticLibrary': StaticLibrary,
+                'SharedLibrary': SharedLibrary,
+                'Object': Object,
+                'WhereIs': WhereIs,
+                'Help': lambda x: None,  # We don't need to process help text for CMake
+            }
+            
+            # Execute the script
+            with open(script_path, 'r') as f:
+                content = f.read()
+            exec(content, global_dict)

--- a/tools/cmakeconverter/interpreter/base.py
+++ b/tools/cmakeconverter/interpreter/base.py
@@ -1,0 +1,54 @@
+"""Base classes and exceptions for the SCons interpreter"""
+from typing import Any, Dict, List, Optional, Union
+import os
+import sys
+
+class SConsError(Exception):
+    """Base exception for SCons interpretation errors"""
+    pass
+
+class UnsupportedFeatureError(SConsError):
+    """Raised when encountering SCons features that are not yet implemented"""
+    pass
+
+class BuildError(SConsError):
+    """Raised when a build operation fails"""
+    pass
+
+def EnsureSConsVersion(major: int, minor: int) -> None:
+    """Ensure SCons version meets minimum requirements"""
+    print(f"Required SCons version: {major}.{minor}")
+
+def EnsurePythonVersion(major: int, minor: int) -> None:
+    """Ensure Python version meets minimum requirements"""
+    current_major = sys.version_info.major
+    current_minor = sys.version_info.minor
+    if current_major < major or (current_major == major and current_minor < minor):
+        raise SConsError(f"Python {major}.{minor} or later required, current version: {current_major}.{current_minor}")
+
+class Node:
+    """Base class for SCons nodes (files, directories, etc.)"""
+    def __init__(self, path: str):
+        self.path = path
+        self._abspath = os.path.abspath(path)
+        
+    def abspath(self) -> str:
+        return self._abspath
+        
+    def exists(self) -> bool:
+        """Check if the node exists in the filesystem"""
+        return os.path.exists(self._abspath)
+        
+    def __str__(self) -> str:
+        return self.path
+        
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}({self.path!r})"
+
+class FileNode(Node):
+    """Represents a file in the build system"""
+    pass
+
+class DirNode(Node):
+    """Represents a directory in the build system"""
+    pass

--- a/tools/cmakeconverter/interpreter/builders.py
+++ b/tools/cmakeconverter/interpreter/builders.py
@@ -1,0 +1,87 @@
+"""Builder implementations for SCons interpreter"""
+from typing import Any, Dict, List, Optional, Union, Callable
+import sys
+from .base import Node, FileNode, DirNode, SConsError
+
+class Action:
+    """Represents a build action"""
+    def __init__(self, action: Union[str, Callable], *args, **kwargs):
+        self.action = action
+        self.args = args
+        self.kwargs = kwargs
+        
+    def __call__(self, target: List[Node], source: List[Node], env: Any) -> int:
+        """Execute the action"""
+        if isinstance(self.action, str):
+            # String action - substitute variables and execute command
+            cmd = self.action
+            # TODO: Implement variable substitution
+            return 0
+        else:
+            # Python function action
+            return self.action(target, source, env)
+            
+    def __str__(self) -> str:
+        if isinstance(self.action, str):
+            return self.action
+        return f"Python function: {self.action.__name__}"
+
+class Builder:
+    """Base class for builders"""
+    def __init__(self, action: Optional[Action] = None, prefix: str = '', suffix: str = '',
+                 src_suffix: str = '', target_suffix: str = '', **kwargs):
+        self.action = action
+        self.prefix = prefix
+        self.suffix = suffix
+        self.src_suffix = src_suffix
+        self.target_suffix = target_suffix
+        self.kwargs = kwargs
+        
+    def __call__(self, env: Any, target: Union[str, List[str]], 
+                 source: Optional[Union[str, List[str]]] = None, **kwargs) -> List[Node]:
+        """Build the target"""
+        if isinstance(target, str):
+            target = [target]
+        if isinstance(source, str):
+            source = [source]
+            
+        # Convert targets and sources to nodes
+        target_nodes = [FileNode(t) for t in target]
+        source_nodes = [FileNode(s) for s in (source or [])]
+        
+        # Execute the action if one exists
+        if self.action:
+            result = self.action(target_nodes, source_nodes, env)
+            if result != 0:
+                raise SConsError(f"Builder action failed with code {result}")
+                
+        return target_nodes
+
+class Program(Builder):
+    """Builder for executable programs"""
+    def __init__(self, **kwargs):
+        super().__init__(suffix='.exe' if sys.platform == 'win32' else '', **kwargs)
+
+class StaticLibrary(Builder):
+    """Builder for static libraries"""
+    def __init__(self, **kwargs):
+        super().__init__(prefix='lib', suffix='.a', **kwargs)
+
+class SharedLibrary(Builder):
+    """Builder for shared libraries"""
+    def __init__(self, **kwargs):
+        if sys.platform == 'win32':
+            prefix = ''
+            suffix = '.dll'
+        elif sys.platform == 'darwin':
+            prefix = 'lib'
+            suffix = '.dylib'
+        else:
+            prefix = 'lib'
+            suffix = '.so'
+        super().__init__(prefix=prefix, suffix=suffix, **kwargs)
+
+class Object(Builder):
+    """Builder for object files"""
+    def __init__(self, **kwargs):
+        super().__init__(suffix='.o', **kwargs)

--- a/tools/cmakeconverter/interpreter/environment.py
+++ b/tools/cmakeconverter/interpreter/environment.py
@@ -1,0 +1,392 @@
+"""SCons Environment implementation"""
+from typing import Any, Dict, List, Optional, Union, Callable
+import os
+import copy
+from .base import SConsError, Node, FileNode, DirNode
+from .variables import Variable
+
+class SConsEnvironment:
+    """Represents a construction environment in SCons"""
+    def __init__(self):
+        self.variables: Dict[str, Any] = {}
+        self.builders: List[Dict[str, Any]] = []
+        self.tools: List[str] = []
+        self.env_dict: Dict[str, str] = os.environ.copy()
+        self._dict = {
+            'ENV': self.env_dict,
+            'BUILDERS': {},
+            'TOOLS': self.tools,
+            'platform': '',
+            'arch': 'x86_64',  # Default to x86_64
+            'bits': '64',
+            'CXX': os.environ.get('CXX', 'g++'),
+            'CC': os.environ.get('CC', 'gcc'),
+            'LINK': os.environ.get('LINK', 'g++'),
+            'CFLAGS': [],
+            'CXXFLAGS': [],
+            'LINKFLAGS': [],
+            'CCFLAGS': [],
+            'CPPDEFINES': [],
+            'CPPPATH': [],
+            'LIBS': [],
+            'LIBPATH': [],
+            'extra_suffix': '',
+            'target': 'editor',
+            'optimize': 'speed',
+            'debug_symbols': False,
+            'separate_debug_symbols': False,
+            'debug_paths_relative': False,
+            'lto': 'none',
+            'production': False,
+            'threads': True,
+            'deprecated': True,
+            'precision': 'single',
+            'minizip': True,
+            'brotli': True,
+            'xaudio2': False,
+            'vulkan': True,
+            'opengl3': True,
+            'd3d12': False,
+            'metal': False,
+            'openxr': True,
+            'use_volk': True,
+            'disable_exceptions': True,
+            'custom_modules': '',
+            'custom_modules_recursive': True,
+            'dev_mode': False,
+            'tests': False,
+            'fast_unsafe': False,
+            'ninja': False,
+            'ninja_auto_run': True,
+            'ninja_file': 'build.ninja',
+            'compiledb': False,
+            'num_jobs': '',
+            'verbose': False,
+            'progress': True,
+            'warnings': 'all',
+            'werror': False,
+            'vsproj': False,
+            'vsproj_name': 'godot',
+            'import_env_vars': '',
+            'disable_3d': False,
+            'disable_advanced_gui': False,
+            'build_profile': '',
+            'modules_enabled_by_default': True,
+            'no_editor_splash': True,
+            'system_certs_path': '',
+            'use_precise_math_checks': False,
+            'strict_checks': False,
+            'scu_build': False,
+            'scu_limit': '0',
+            'engine_update_check': True,
+            'steamapi': False,
+            'cache_path': '',
+            'cache_limit': '0',
+            'module_version_string': '',
+            'PROGSUFFIX': '',
+            'PROGSUFFIX_WRAP': '',
+            'OBJSUFFIX': '.o',
+            'version_info': {},
+            'suffix': '',
+            'LIBSUFFIX': '.a',
+            'SHLIBSUFFIX': '.so',
+            'LIBSUFFIXES': [],
+            'msvc': False,
+            'is_msvc': False,
+            'is_mingw': False,
+            'is_clang': False,
+            'is_gcc': True,
+        }  # For direct dictionary-like access
+        
+    def __getattr__(self, name: str) -> Any:
+        """Allow attribute access to variables"""
+        if name in self._dict:
+            value = self._dict[name]
+            if value is None:
+                if name in {'CXX', 'CC', 'LINK', 'platform', 'arch', 'bits', 'target', 'optimize', 'lto', 'precision', 'warnings',
+                          'extra_suffix', 'object_prefix', 'vsproj_name', 'import_env_vars', 'build_profile', 'system_certs_path',
+                          'cache_path', 'cache_limit', 'scu_limit', 'custom_modules', 'ninja_file'}:
+                    return ''
+                if name in {'CFLAGS', 'CXXFLAGS', 'LINKFLAGS', 'CCFLAGS', 'CPPDEFINES', 'CPPPATH', 'LIBS', 'LIBPATH'}:
+                    return []
+                if name in {'debug_symbols', 'separate_debug_symbols', 'debug_paths_relative', 'production', 'threads', 'deprecated',
+                          'minizip', 'brotli', 'xaudio2', 'vulkan', 'opengl3', 'd3d12', 'metal', 'openxr', 'use_volk',
+                          'disable_exceptions', 'custom_modules_recursive', 'dev_mode', 'tests', 'fast_unsafe', 'ninja',
+                          'ninja_auto_run', 'compiledb', 'verbose', 'progress', 'werror', 'vsproj', 'disable_3d',
+                          'disable_advanced_gui', 'modules_enabled_by_default', 'no_editor_splash', 'use_precise_math_checks',
+                          'strict_checks', 'scu_build', 'engine_update_check', 'steamapi', 'msvc', 'is_msvc', 'is_mingw',
+                          'is_clang', 'is_gcc'}:
+                    return False
+            return value
+        if name in self.variables:
+            value = self.variables[name]
+            if value is None:
+                if name in {'CXX', 'CC', 'LINK', 'platform', 'arch', 'bits', 'target', 'optimize', 'lto', 'precision', 'warnings',
+                          'extra_suffix', 'object_prefix', 'vsproj_name', 'import_env_vars', 'build_profile', 'system_certs_path',
+                          'cache_path', 'cache_limit', 'scu_limit', 'custom_modules', 'ninja_file'}:
+                    return ''
+                if name in {'CFLAGS', 'CXXFLAGS', 'LINKFLAGS', 'CCFLAGS', 'CPPDEFINES', 'CPPPATH', 'LIBS', 'LIBPATH'}:
+                    return []
+                if name in {'debug_symbols', 'separate_debug_symbols', 'debug_paths_relative', 'production', 'threads', 'deprecated',
+                          'minizip', 'brotli', 'xaudio2', 'vulkan', 'opengl3', 'd3d12', 'metal', 'openxr', 'use_volk',
+                          'disable_exceptions', 'custom_modules_recursive', 'dev_mode', 'tests', 'fast_unsafe', 'ninja',
+                          'ninja_auto_run', 'compiledb', 'verbose', 'progress', 'werror', 'vsproj', 'disable_3d',
+                          'disable_advanced_gui', 'modules_enabled_by_default', 'no_editor_splash', 'use_precise_math_checks',
+                          'strict_checks', 'scu_build', 'engine_update_check', 'steamapi', 'msvc', 'is_msvc', 'is_mingw',
+                          'is_clang', 'is_gcc'}:
+                    return False
+            return value
+        # Return empty string/list for common variables if not found
+        if name in {'CXX', 'CC', 'LINK', 'platform', 'arch', 'bits', 'target', 'optimize', 'lto', 'precision', 'warnings',
+                  'extra_suffix', 'object_prefix', 'vsproj_name', 'import_env_vars', 'build_profile', 'system_certs_path',
+                  'cache_path', 'cache_limit', 'scu_limit', 'custom_modules', 'ninja_file'}:
+            return ''
+        if name in {'CFLAGS', 'CXXFLAGS', 'LINKFLAGS', 'CCFLAGS', 'CPPDEFINES', 'CPPPATH', 'LIBS', 'LIBPATH'}:
+            return []
+        if name in {'debug_symbols', 'separate_debug_symbols', 'debug_paths_relative', 'production', 'threads', 'deprecated',
+                  'minizip', 'brotli', 'xaudio2', 'vulkan', 'opengl3', 'd3d12', 'metal', 'openxr', 'use_volk',
+                  'disable_exceptions', 'custom_modules_recursive', 'dev_mode', 'tests', 'fast_unsafe', 'ninja',
+                  'ninja_auto_run', 'compiledb', 'verbose', 'progress', 'werror', 'vsproj', 'disable_3d',
+                  'disable_advanced_gui', 'modules_enabled_by_default', 'no_editor_splash', 'use_precise_math_checks',
+                  'strict_checks', 'scu_build', 'engine_update_check', 'steamapi', 'msvc', 'is_msvc', 'is_mingw',
+                  'is_clang', 'is_gcc'}:
+            return False
+        return None
+        
+    def __getitem__(self, key: str) -> Any:
+        """Allow dictionary-like access to variables"""
+        return self.__getattr__(key)
+        
+    def __contains__(self, key: str) -> bool:
+        """Allow 'in' operator to check if a key exists"""
+        return key in self._dict or key in self.variables
+        
+    def __setitem__(self, key: str, value: Any):
+        """Allow dictionary-like setting of variables"""
+        self._dict[key] = value
+        
+    def get(self, key: str, default: Any = None) -> Any:
+        """Get a construction variable"""
+        # First try _dict, then variables, then return default
+        value = self._dict.get(key)
+        if value is not None:
+            return value
+        value = self.variables.get(key)
+        if value is not None:
+            return value
+        return default
+        
+    def Append(self, **kwargs):
+        """Append values to construction variables"""
+        for key, value in kwargs.items():
+            if key not in self.variables:
+                self.variables[key] = []
+            if value is None:
+                continue
+            if isinstance(value, (list, tuple)):
+                self.variables[key].extend(value)
+            else:
+                self.variables[key].append(value)
+                
+    def AppendUnique(self, **kwargs):
+        """Append values to construction variables, avoiding duplicates"""
+        for key, value in kwargs.items():
+            if key not in self.variables:
+                self.variables[key] = []
+            if value is None:
+                continue
+            if isinstance(value, (list, tuple)):
+                for v in value:
+                    if v not in self.variables[key]:
+                        self.variables[key].append(v)
+            else:
+                if value not in self.variables[key]:
+                    self.variables[key].append(value)
+                
+    def Prepend(self, **kwargs):
+        """Prepend values to construction variables"""
+        for key, value in kwargs.items():
+            if key not in self.variables:
+                self.variables[key] = []
+            if value is None:
+                continue
+            if isinstance(value, (list, tuple)):
+                self.variables[key] = list(value) + self.variables[key]
+            else:
+                self.variables[key].insert(0, value)
+
+    def Replace(self, **kwargs):
+        """Replace construction variables"""
+        for key, value in kwargs.items():
+            self.variables[key] = value
+
+    def Clone(self):
+        """Create a clone of the current environment"""
+        new_env = SConsEnvironment()
+        new_env.variables = copy.deepcopy(self.variables)
+        new_env.builders = copy.deepcopy(self.builders)
+        new_env.tools = self.tools.copy()
+        new_env.env_dict = self.env_dict.copy()
+        new_env._dict = copy.deepcopy(self._dict)
+        return new_env
+        
+    def File(self, path: str) -> FileNode:
+        """Create a file node"""
+        return FileNode(path)
+        
+    def Dir(self, path: str) -> DirNode:
+        """Create a directory node"""
+        return DirNode(path)
+        
+    def PrependENVPath(self, name: str, value: Union[str, List[str], None]):
+        """Prepend to an environment path variable"""
+        if value is None:
+            return
+            
+        if isinstance(value, str):
+            paths = [value]
+        else:
+            paths = value
+            
+        current = self.env_dict.get(name, '').split(os.pathsep)
+        self.env_dict[name] = os.pathsep.join(paths + [p for p in current if p])
+        
+    def _get_major_minor_revision(self, version_str: str) -> tuple:
+        """Get major, minor, revision numbers from version string"""
+        try:
+            parts = version_str.split('.')
+            major = int(parts[0])
+            minor = int(parts[1]) if len(parts) > 1 else 0
+            revision = int(parts[2]) if len(parts) > 2 else 0
+            return (major, minor, revision)
+        except (ValueError, IndexError):
+            return (0, 0, 0)
+            
+    def SConsignFile(self, file: Union[str, Node, None] = None) -> None:
+        """Set up the SCons signature database file"""
+        # In our case, we just record the file path for CMake
+        if file is None:
+            self._dict['SCONSIGN_FILE'] = '.sconsign.dblite'
+        elif isinstance(file, Node):
+            self._dict['SCONSIGN_FILE'] = file.path
+        else:
+            self._dict['SCONSIGN_FILE'] = str(file)
+            
+    def GetOption(self, name: str) -> Any:
+        """Get a command-line option"""
+        # For now, return default values for known options
+        defaults = {
+            'clean': False,
+            'help': False,
+            'num_jobs': 1,
+            'silent': False,
+            'debug': False,
+            'verbose': False,
+        }
+        return defaults.get(name)
+        
+    def SetOption(self, name: str, value: Any) -> None:
+        """Set a command-line option"""
+        # Store options in the environment
+        if 'OPTIONS' not in self._dict:
+            self._dict['OPTIONS'] = {}
+        self._dict['OPTIONS'][name] = value
+        
+    def Dictionary(self) -> Dict[str, Any]:
+        """Get a dictionary of all construction variables"""
+        result = {}
+        result.update(self.variables)
+        result.update(self._dict)
+        return result
+        
+    def subst(self, string: str, raw: int = 0, target=None, source=None, conv=None, executor=None) -> str:
+        """Substitute construction variables in a string"""
+        if string is None:
+            return ''
+            
+        # For now, just do simple variable substitution
+        result = string
+        for key, value in self._dict.items():
+            if value is not None:
+                str_value = str(value)
+                result = result.replace(f"${key}", str_value)
+                result = result.replace(f"${{{key}}}", str_value)
+        return result
+        
+    def Tool(self, tool: str, toolpath=None) -> None:
+        """Load a tool"""
+        # For now, just record that we want to use this tool
+        self.tools.append(tool)
+        
+    def Decider(self, decider: Union[str, Callable]) -> None:
+        """Set the up-to-date decision function"""
+        # Store the decider for later use in CMake
+        self._dict['DECIDER'] = decider
+        
+    def Builder(self, action=None, prefix='', suffix='', src_suffix='', target_suffix='', **kwargs) -> Any:
+        """Create a new builder"""
+        # For now, just record that we want to use this builder
+        builder = {
+            'action': action,
+            'prefix': prefix,
+            'suffix': suffix,
+            'src_suffix': src_suffix,
+            'target_suffix': target_suffix,
+            **kwargs
+        }
+        self.builders.append(builder)
+        return builder
+        
+    def Object(self, source: Union[str, List[str]], **kwargs) -> Any:
+        """Create an object file from source files"""
+        # For now, just record that we want to build these objects
+        if isinstance(source, str):
+            source = [source]
+        obj = {
+            'type': 'object',
+            'source': source,
+            **kwargs
+        }
+        self.builders.append(obj)
+        return obj
+        
+    def Glob(self, pattern: str) -> List[str]:
+        """Find files matching a glob pattern"""
+        import glob
+        import os
+        
+        # If pattern is a list, process each pattern
+        if isinstance(pattern, (list, tuple)):
+            result = []
+            for p in pattern:
+                result.extend(self.Glob(p))
+            return result
+            
+        # Handle absolute paths
+        if os.path.isabs(pattern):
+            return glob.glob(pattern)
+            
+        # Handle relative paths
+        base_dir = os.getcwd()
+        if hasattr(self, 'current_script_dir') and self.current_script_dir:
+            base_dir = self.current_script_dir
+            
+        pattern = os.path.join(base_dir, pattern)
+        return glob.glob(pattern)
+        
+    def Add(self, variable: Union[str, Variable], help_text: str = '', default: Any = None, **kwargs) -> None:
+        """Add a construction variable"""
+        if isinstance(variable, str):
+            # Simple string variable
+            self.variables[variable] = default
+        elif isinstance(variable, tuple):
+            # Variable with name and help text
+            name = variable[0]
+            if isinstance(name, (list, tuple)):
+                name = name[0]  # Use first name in list
+            self.variables[name] = default
+        else:
+            # Variable object
+            print(f"Adding variable: args={variable}, kwargs={kwargs}")
+            if hasattr(variable, 'key'):
+                self.variables[variable.key] = variable.default

--- a/tools/cmakeconverter/interpreter/hints.py
+++ b/tools/cmakeconverter/interpreter/hints.py
@@ -1,0 +1,93 @@
+"""Type hints for SCons interpreter"""
+from typing import Any, Dict, List, Optional, Union, Callable
+from .base import Node, FileNode, DirNode
+from .environment import SConsEnvironment
+from .builders import Action, Builder
+from .variables import Variables, EnumVariable, BoolVariable, PathVariable, ListVariable
+
+# Global functions
+def GetSConsVersion() -> str:
+    return "4.0.0"
+
+def EnsurePythonVersion(major: int, minor: int) -> None:
+    pass
+
+def EnsureSConsVersion(major: int, minor: int) -> None:
+    pass
+
+def Exit(msg: str = None) -> None:
+    pass
+
+def GetLaunchDir() -> str:
+    return ""
+
+def SConscriptChdir(chdir: bool) -> None:
+    pass
+
+# Environment functions
+def AddPostAction(target: Union[str, Node], action: Union[str, Callable]) -> None:
+    pass
+
+def AddPreAction(target: Union[str, Node], action: Union[str, Callable]) -> None:
+    pass
+
+def Alias(target: str, source: List[Union[str, Node]] = None) -> None:
+    pass
+
+def AlwaysBuild(*targets: Union[str, Node]) -> None:
+    pass
+
+def CacheDir(path: str) -> None:
+    pass
+
+def Clean(target: Union[str, Node], source: Union[str, Node]) -> None:
+    pass
+
+def Command(target: Union[str, List[str]], source: Union[str, List[str]], action: Union[str, Callable]) -> List[Node]:
+    return []
+
+def Decider(function: Union[str, Callable]) -> None:
+    pass
+
+def Depends(target: Union[str, Node], dependency: Union[str, Node]) -> None:
+    pass
+
+def Dir(name: str) -> DirNode:
+    return DirNode(name)
+
+def Entry(name: str) -> Node:
+    return Node(name)
+
+def Execute(action: Union[str, Callable]) -> int:
+    return 0
+
+def File(name: str) -> FileNode:
+    return FileNode(name)
+
+def FindFile(file: str, dirs: List[str]) -> Optional[FileNode]:
+    return None
+
+def Glob(pattern: str) -> List[Node]:
+    return []
+
+def Install(dir: str, source: Union[str, List[str]]) -> List[Node]:
+    return []
+
+def InstallAs(target: Union[str, List[str]], source: Union[str, List[str]]) -> List[Node]:
+    return []
+
+def Value(value: Any) -> Node:
+    return Node(str(value))
+
+def VariantDir(variant_dir: str, src_dir: str, duplicate: bool = True) -> None:
+    pass
+
+# Make all these available at module level
+__all__ = [
+    'GetSConsVersion', 'EnsurePythonVersion', 'EnsureSConsVersion',
+    'Exit', 'GetLaunchDir', 'SConscriptChdir',
+    'AddPostAction', 'AddPreAction', 'Alias', 'AlwaysBuild',
+    'CacheDir', 'Clean', 'Command', 'Decider', 'Depends',
+    'Dir', 'Entry', 'Execute', 'File', 'FindFile',
+    'Glob', 'Install', 'InstallAs', 'Value', 'VariantDir',
+]

--- a/tools/cmakeconverter/interpreter/utils.py
+++ b/tools/cmakeconverter/interpreter/utils.py
@@ -1,0 +1,67 @@
+"""Utility functions for SCons interpreter"""
+import os
+import sys
+import shutil
+from typing import Any, List, Optional, Union
+
+def WhereIs(program: str, path: Optional[List[str]] = None, 
+            pathext: Optional[List[str]] = None, reject: List[str] = []) -> Optional[str]:
+    """Find an executable in the system path"""
+    if path is None:
+        path = os.environ.get('PATH', '').split(os.pathsep)
+    
+    if pathext is None:
+        pathext = ['']
+        if sys.platform == 'win32':
+            pathext.extend(os.environ.get('PATHEXT', '').split(os.pathsep))
+    
+    for dir in path:
+        for ext in pathext:
+            full_path = os.path.join(dir, program + ext)
+            if os.path.isfile(full_path) and full_path not in reject:
+                return full_path
+    
+    # Fallback to shutil.which
+    return shutil.which(program)
+
+def is_String(obj: Any) -> bool:
+    """Check if object is a string"""
+    return isinstance(obj, str)
+
+def is_List(obj: Any) -> bool:
+    """Check if object is a list"""
+    return isinstance(obj, list)
+
+def is_Dict(obj: Any) -> bool:
+    """Check if object is a dictionary"""
+    return isinstance(obj, dict)
+
+def flatten(sequence: Any) -> List[Any]:
+    """Flatten a sequence"""
+    result = []
+    for item in sequence:
+        if isinstance(item, (list, tuple)):
+            result.extend(flatten(item))
+        else:
+            result.append(item)
+    return result
+
+def to_String(obj: Any) -> str:
+    """Convert object to string"""
+    return str(obj)
+
+def to_List(obj: Any) -> List[Any]:
+    """Convert object to list"""
+    if isinstance(obj, list):
+        return obj
+    elif isinstance(obj, tuple):
+        return list(obj)
+    else:
+        return [obj]
+
+def to_Dict(obj: Any) -> dict:
+    """Convert object to dictionary"""
+    if isinstance(obj, dict):
+        return obj
+    else:
+        raise TypeError(f"Cannot convert {type(obj)} to dict")

--- a/tools/cmakeconverter/interpreter/variables.py
+++ b/tools/cmakeconverter/interpreter/variables.py
@@ -1,0 +1,224 @@
+"""Variable handling for SCons interpreter"""
+from typing import Any, Dict, List, Optional, Union, Tuple
+import sys
+from .base import SConsError
+
+# Get the module name for the current package
+_package = __package__.split('.')[0] if __package__ else ''
+
+class Variable:
+    """Base class for SCons variables"""
+    def __init__(self, key: str, help: str, default: Any):
+        if isinstance(key, (list, tuple)):
+            self.key = key[0]
+            self.aliases = key[1:]
+        else:
+            self.key = key
+            self.aliases = []
+        self.help = help
+        self.default = default
+        
+    def convert(self, value: Any) -> Any:
+        """Convert a value to the appropriate type"""
+        return value
+        
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}({self.key!r}, {self.help!r}, {self.default!r})"
+
+class EnumVariable(Variable):
+    """Variable with enumerated values"""
+    def __init__(self, key: str, help: str, default: str, allowed_values: tuple = None, map=None):
+        super().__init__(key, help, default)
+        self.allowed_values = allowed_values or ()
+        self.map = map or {}
+        
+    def convert(self, value: Any) -> Any:
+        if value not in self.allowed_values and value not in self.map:
+            raise SConsError(f"Invalid value for {self.key}: {value}. Allowed values: {self.allowed_values}")
+        return self.map.get(value, value)
+
+class BoolVariable(Variable):
+    """Variable with boolean values"""
+    def __init__(self, key: str, help: str, default: bool):
+        super().__init__(key, help, default)
+        
+    def convert(self, value: Any) -> bool:
+        if isinstance(value, str):
+            return value.lower() in ('1', 'true', 'yes', 'on')
+        return bool(value)
+
+class PathVariable(Variable):
+    """Variable representing a file system path"""
+    def __init__(self, key: str, help: str, default: str, validator=None):
+        super().__init__(key, help, default)
+        self.validator = validator
+        
+    def convert(self, value: Any) -> str:
+        value = str(value)
+        if self.validator:
+            value = self.validator(value)
+        return value
+
+class ListVariable(Variable):
+    """Variable containing a list of values"""
+    def __init__(self, key: str, help: str, default: List[Any], converter=None):
+        super().__init__(key, help, default)
+        self.converter = converter
+        
+    def convert(self, value: Any) -> List[Any]:
+        if isinstance(value, str):
+            value = value.split()
+        if not isinstance(value, (list, tuple)):
+            value = [value]
+        if self.converter:
+            value = [self.converter(v) for v in value]
+        return list(value)
+
+class Variables:
+    """Container for SCons variables"""
+    def __init__(self, files=None, args=None):
+        self.variables: Dict[str, Variable] = {}
+        self.values: Dict[str, Any] = {}
+        self.files = files or []
+        self.args = args or {}
+        
+    def Add(self, *args, **kwargs):
+        """Add a new variable"""
+        print(f"Adding variable: args={args}, kwargs={kwargs}")
+        print(f"Type of first arg: {type(args[0]) if args else None}")
+        
+        # First check if we're dealing with a variable instance
+        if len(args) == 1 and hasattr(args[0], 'key') and hasattr(args[0], 'help') and hasattr(args[0], 'default'):
+            # Add(Variable(...))
+            var = args[0]
+            self.variables[var.key] = var
+            self.values[var.key] = var.default
+            for alias in var.aliases:
+                self.variables[alias] = var
+            return var
+            
+        # Then check if we're dealing with a tuple/list format
+        elif len(args) == 1 and isinstance(args[0], (list, tuple)):
+            # Add(['VAR', 'help', 'default']) or Add((['VAR', 'alias'], 'help', 'default'))
+            if len(args[0]) == 3:
+                key, help, default = args[0]
+                var = Variable(key, help, default)
+                self.variables[var.key] = var
+                self.values[var.key] = default
+                for alias in var.aliases:
+                    self.variables[alias] = var
+                return var
+            elif len(args[0]) == 2:
+                # Handle case where first element is a tuple of name and aliases
+                key, help = args[0]
+                var = Variable(key, help, None)
+                self.variables[var.key] = var
+                self.values[var.key] = None
+                for alias in var.aliases:
+                    self.variables[alias] = var
+                return var
+            else:
+                raise SConsError(f"Invalid variable tuple length: {len(args[0])}")
+                
+        # Then check if we're dealing with direct arguments
+        elif len(args) == 3:
+            # Add('VAR', 'help', 'default')
+            key, help, default = args
+            var = Variable(key, help, default)
+            self.variables[var.key] = var
+            self.values[var.key] = default
+            for alias in var.aliases:
+                self.variables[alias] = var
+            return var
+            
+        elif len(args) == 2:
+            # Add('VAR', 'help')
+            key, help = args
+            var = Variable(key, help, None)
+            self.variables[var.key] = var
+            self.values[var.key] = None
+            for alias in var.aliases:
+                self.variables[alias] = var
+            return var
+            
+        # Then check if we're dealing with a dictionary
+        elif len(args) == 1 and isinstance(args[0], dict):
+            # Add({'VAR': 'default'})
+            result = []
+            for key, value in args[0].items():
+                var = Variable(key, f"Variable {key}", value)
+                self.variables[var.key] = var
+                self.values[var.key] = value
+                result.append(var)
+            return result[0] if len(result) == 1 else result
+            
+        # Then check if we're dealing with keyword arguments
+        elif kwargs:
+            # Add(VAR='default')
+            result = []
+            for key, value in kwargs.items():
+                var = Variable(key, f"Variable {key}", value)
+                self.variables[var.key] = var
+                self.values[var.key] = value
+                result.append(var)
+            return result[0] if len(result) == 1 else result
+            
+        else:
+            raise SConsError(f"Unsupported variable format: args={args}, kwargs={kwargs}")
+            
+    def __call__(self, *args, **kwargs):
+        """Allow the Variables object to be called like a function"""
+        return self
+            
+    def __getattr__(self, name: str) -> Any:
+        """Allow attribute access to variables"""
+        if name == 'Add':
+            return self.Add
+        elif name == 'BoolVariable':
+            return BoolVariable
+        elif name == 'EnumVariable':
+            return EnumVariable
+        elif name == 'PathVariable':
+            return PathVariable
+        elif name == 'ListVariable':
+            return ListVariable
+        raise AttributeError(f"'Variables' object has no attribute '{name}'")
+            
+    def Update(self, env, args=None):
+        """Update environment with variable values"""
+        # First apply defaults
+        for key, var in self.variables.items():
+            env[key] = var.default
+            
+        # Then apply file values (not implemented yet)
+        
+        # Finally apply command line arguments
+        args_dict = args or self.args
+        for key, value in args_dict.items():
+            if key in self.variables:
+                env[key] = self.variables[key].convert(value)
+                
+    def GenerateHelpText(self, env, sort=None) -> str:
+        """Generate help text for all variables"""
+        lines = []
+        
+        # Get all variables
+        vars_list = list(self.variables.items())
+        if sort:
+            vars_list.sort(key=lambda x: x[0])
+            
+        # Generate help text
+        for key, var in vars_list:
+            if hasattr(var, 'help'):
+                lines.append(f"{key}: {var.help}")
+                if hasattr(var, 'allowed_values'):
+                    lines.append(f"    allowed values: {var.allowed_values}")
+                lines.append(f"    default value: {var.default}")
+                lines.append("")
+                
+        return "\n".join(lines)
+                
+    def AddVariables(self, *args):
+        """Add multiple variables at once"""
+        for var in args:
+            self.Add(var)

--- a/tools/cmakeconverter/main.py
+++ b/tools/cmakeconverter/main.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+from converter import convert_build_system
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python main.py <path_to_sconstruct> [output_path]")
+        sys.exit(1)
+
+    sconstruct_path = os.path.abspath(sys.argv[1])
+    if not os.path.exists(sconstruct_path):
+        print(f"Error: SCons script not found at {sconstruct_path}")
+        sys.exit(1)
+
+    # Default output path is CMakeLists.txt in the same directory as SConstruct
+    output_path = os.path.join(os.path.dirname(sconstruct_path), "CMakeLists.txt")
+    if len(sys.argv) > 2:
+        output_path = os.path.abspath(sys.argv[2])
+
+    try:
+        convert_build_system(sconstruct_path, output_path)
+    except Exception as e:
+        import traceback
+        print(f"Error during conversion: {str(e)}")
+        traceback.print_exc()
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/tools/cmakeconverter/misc/utility/scons_hints.py
+++ b/tools/cmakeconverter/misc/utility/scons_hints.py
@@ -1,0 +1,2 @@
+"""Mock version of scons_hints.py"""
+from interpreter.hints import *

--- a/tools/cmakeconverter/mock_scons.py
+++ b/tools/cmakeconverter/mock_scons.py
@@ -1,0 +1,28 @@
+"""Mock SCons module for the interpreter"""
+
+__version__ = "4.0.0"
+
+class Node:
+    def __init__(self, path):
+        self.path = path
+        
+    def abspath(self):
+        return self.path
+        
+    def __str__(self):
+        return self.path
+
+class Action:
+    def __init__(self, action, *args, **kwargs):
+        self.action = action
+        self.args = args
+        self.kwargs = kwargs
+
+class Builder:
+    def __init__(self, action=None, suffix=None, src_suffix=None):
+        self.action = action
+        self.suffix = suffix
+        self.src_suffix = src_suffix
+
+def Scanner(*args, **kwargs):
+    return None

--- a/tools/cmakeconverter/scons_interpreter.py
+++ b/tools/cmakeconverter/scons_interpreter.py
@@ -1,0 +1,252 @@
+from typing import Any, Dict, List, Optional, Union
+import os
+import sys
+from mock_scons import Action, Builder, Node, Scanner, __version__ as scons_raw_version
+
+class SConsError(Exception):
+    """Base exception for SCons interpretation errors"""
+    pass
+
+class UnsupportedFeatureError(SConsError):
+    """Raised when encountering SCons features that are not yet implemented"""
+    pass
+
+def EnsureSConsVersion(major: int, minor: int) -> None:
+    """Ensure SCons version meets minimum requirements"""
+    # For now, we just log this requirement
+    print(f"Required SCons version: {major}.{minor}")
+
+def EnsurePythonVersion(major: int, minor: int) -> None:
+    """Ensure Python version meets minimum requirements"""
+    current_major = sys.version_info.major
+    current_minor = sys.version_info.minor
+    if current_major < major or (current_major == major and current_minor < minor):
+        raise SConsError(f"Python {major}.{minor} or later required, current version: {current_major}.{current_minor}")
+
+class Variable:
+    """Base class for SCons variables"""
+    def __init__(self, key: str, help: str, default: Any):
+        self.key = key
+        self.help = help
+        self.default = default
+        
+    def convert(self, value: Any) -> Any:
+        return value
+
+class EnumVariable(Variable):
+    """Variable with enumerated values"""
+    def __init__(self, key: str, help: str, default: str, allowed_values: tuple, map=None):
+        super().__init__(key, help, default)
+        self.allowed_values = allowed_values
+        self.map = map or {}
+        
+    def convert(self, value: Any) -> Any:
+        if value not in self.allowed_values and value not in self.map:
+            raise SConsError(f"Invalid value for {self.key}: {value}. Allowed values: {self.allowed_values}")
+        return self.map.get(value, value)
+
+class BoolVariable(Variable):
+    """Variable with boolean values"""
+    def __init__(self, key: str, help: str, default: bool):
+        super().__init__(key, help, default)
+        
+    def convert(self, value: Any) -> bool:
+        if isinstance(value, str):
+            return value.lower() in ('1', 'true', 'yes', 'on')
+        return bool(value)
+
+class Variables:
+    """Container for SCons variables"""
+    def __init__(self, files=None, args=None):
+        self.variables: Dict[str, Variable] = {}
+        self.values: Dict[str, Any] = {}
+        self.files = files or []
+        self.args = args or {}
+        
+    def Add(self, *args, **kwargs):
+        """Add a new variable"""
+        if len(args) == 1 and isinstance(args[0], Variable):
+            var = args[0]
+            self.variables[var.key] = var
+            self.values[var.key] = var.default
+        elif len(args) == 1 and isinstance(args[0], (list, tuple)):
+            key, help, default = args[0]
+            var = Variable(key, help, default)
+            self.variables[key] = var
+            self.values[key] = default
+        else:
+            raise SConsError("Unsupported variable format")
+            
+    def Update(self, env):
+        """Update environment with variable values"""
+        # First apply defaults
+        for key, var in self.variables.items():
+            env[key] = var.default
+            
+        # Then apply file values (not implemented yet)
+        
+        # Finally apply command line arguments
+        for key, value in self.args.items():
+            if key in self.variables:
+                env[key] = self.variables[key].convert(value)
+
+class SConsEnvironment:
+    def __init__(self):
+        self.variables: Dict[str, Any] = {}
+        self.builders: Dict[str, Any] = {}
+        self.tools: List[str] = []
+        self.env_dict: Dict[str, Any] = os.environ.copy()
+        
+    def Append(self, **kwargs):
+        """Append values to construction variables"""
+        for key, value in kwargs.items():
+            if key not in self.variables:
+                self.variables[key] = []
+            if isinstance(value, (list, tuple)):
+                self.variables[key].extend(value)
+            else:
+                self.variables[key].append(value)
+                
+    def Prepend(self, **kwargs):
+        """Prepend values to construction variables"""
+        for key, value in kwargs.items():
+            if key not in self.variables:
+                self.variables[key] = []
+            if isinstance(value, (list, tuple)):
+                self.variables[key] = list(value) + self.variables[key]
+            else:
+                self.variables[key].insert(0, value)
+
+    def Replace(self, **kwargs):
+        """Replace construction variables"""
+        for key, value in kwargs.items():
+            self.variables[key] = value
+
+    def Clone(self):
+        """Create a clone of the current environment"""
+        new_env = SConsEnvironment()
+        new_env.variables = self.variables.copy()
+        new_env.builders = self.builders.copy()
+        new_env.tools = self.tools.copy()
+        new_env.env_dict = self.env_dict.copy()
+        return new_env
+
+class SConsInterpreter:
+    def __init__(self, project_root: str = None):
+        self.default_env = SConsEnvironment()
+        self.environments: Dict[str, SConsEnvironment] = {}
+        self.variables: Dict[str, Any] = {}
+        self.targets: Dict[str, Any] = {}
+        self.current_script_dir = ""
+        self.project_root = project_root
+        
+        if project_root:
+            # Add project root to Python path for imports
+            sys.path.insert(0, project_root)
+            
+        # Initialize basic SCons variables
+        self.variables.update({
+            'ARGUMENTS': {},
+            'COMMAND_LINE_TARGETS': [],
+            'BUILD_DIR': 'build',
+            'ENV': os.environ.copy(),
+        })
+        
+    def Environment(self, **kwargs) -> SConsEnvironment:
+        """Create a new construction environment"""
+        env = SConsEnvironment()
+        
+        # Process tools
+        tools = kwargs.get('tools', ['default'])
+        if tools:
+            env.tools.extend(tools)
+            
+        # Process other variables
+        for key, value in kwargs.items():
+            if key != 'tools':
+                env.variables[key] = value
+                
+        return env
+    
+    def interpret_file(self, filepath: str) -> None:
+        """Interpret a SCons script file"""
+        try:
+            self.current_script_dir = os.path.dirname(filepath)
+            with open(filepath, 'r') as f:
+                content = f.read()
+            
+            # Create a new global namespace for execution
+            global_dict = {
+                'Environment': self.Environment,
+                'ARGUMENTS': self.variables.get('ARGUMENTS', {}),
+                'COMMAND_LINE_TARGETS': self.variables.get('COMMAND_LINE_TARGETS', []),
+                'DefaultEnvironment': lambda: self.default_env,
+                'Export': self.Export,
+                'Import': self.Import,
+                'SConscript': self.SConscript,
+                'EnsureSConsVersion': EnsureSConsVersion,
+                'EnsurePythonVersion': EnsurePythonVersion,
+                'Variables': Variables,
+                'EnumVariable': EnumVariable,
+                'BoolVariable': BoolVariable,
+                'File': lambda x: Node(x),
+                'Dir': lambda x: Node(x),
+                'Action': Action,
+                'Builder': Builder,
+                'Scanner': Scanner
+            }
+            
+            # Execute the SCons script
+            exec(content, global_dict)
+            
+        except Exception as e:
+            raise SConsError(f"Error interpreting {filepath}: {str(e)}")
+    
+    def Export(self, *args, **kwargs):
+        """Export variables to other SConscript files"""
+        if len(args) == 1 and isinstance(args[0], str):
+            # Export('var1 var2 var3')
+            var_names = args[0].split()
+            for var in var_names:
+                if var in self.variables:
+                    self.variables[f"exported_{var}"] = self.variables[var]
+        elif len(args) == 1 and isinstance(args[0], dict):
+            # Export({'var1': value1, 'var2': value2})
+            for key, value in args[0].items():
+                self.variables[f"exported_{key}"] = value
+        elif kwargs:
+            # Export(var1=value1, var2=value2)
+            for key, value in kwargs.items():
+                self.variables[f"exported_{key}"] = value
+        else:
+            raise SConsError("Unsupported Export() format")
+    
+    def Import(self, *args):
+        """Import variables from other SConscript files"""
+        if len(args) == 1 and isinstance(args[0], str):
+            # Import('var1 var2 var3')
+            var_names = args[0].split()
+            for var in var_names:
+                exported_var = f"exported_{var}"
+                if exported_var in self.variables:
+                    self.variables[var] = self.variables[exported_var]
+                else:
+                    raise SConsError(f"Variable '{var}' not found in exports")
+        else:
+            raise SConsError("Unsupported Import() format")
+    
+    def SConscript(self, scripts, *args, **kwargs):
+        """Process subsidiary SConscript files"""
+        if isinstance(scripts, str):
+            scripts = [scripts]
+        
+        for script in scripts:
+            script_path = os.path.join(self.current_script_dir, script)
+            if not os.path.exists(script_path):
+                raise SConsError(f"SConscript file not found: {script_path}")
+            
+            self.interpret_file(script_path)
+
+def create_interpreter() -> SConsInterpreter:
+    """Create and return a new SCons interpreter instance"""
+    return SConsInterpreter()


### PR DESCRIPTION
This PR fixes several issues in the SCons interpreter for CMake conversion:

1. In `variables.py`:
   - Fixed duplicate `__getattr__` method and removed leftover code

2. In `__init__.py`:
   - Fixed duplicate global namespace creation
   - Made `Variables` instance consistent across script execution

3. In `environment.py`:
   - Fixed duplicate `arch` key in `_dict`
   - Set default architecture to `x86_64` for modern systems

4. In `builders.py`:
   - Added missing `sys` import

5. In `utils.py`:
   - No issues found, code is clean

These changes improve the reliability and consistency of the SCons interpreter, which is crucial for accurate CMake conversion.