### PR TITLE
Add SCons to CMake converter tool

### DIFF
--- a/tools/cmakeconverter/SCons/Script/__init__.py
+++ b/tools/cmakeconverter/SCons/Script/__init__.py
@@ -1,6 +1,6 @@
 """Mock SCons.Script module"""
-from interpreter.variables import Variables, EnumVariable, BoolVariable, PathVariable, ListVariable
-from interpreter.builders import Action, Builder, Program, StaticLibrary, SharedLibrary, Object
+from tools.cmakeconverter.interpreter.variables import Variables, EnumVariable, BoolVariable, PathVariable, ListVariable
+from tools.cmakeconverter.interpreter.builders import Action, Builder, Program, StaticLibrary, SharedLibrary, Object
 
 # Global variables
 ARGUMENTS = {}

--- a/tools/cmakeconverter/SCons/Variables/__init__.py
+++ b/tools/cmakeconverter/SCons/Variables/__init__.py
@@ -1,4 +1,4 @@
 """Mock SCons.Variables package"""
-from interpreter.variables import Variables, EnumVariable, BoolVariable, PathVariable, ListVariable
+from tools.cmakeconverter.interpreter.variables import Variables, EnumVariable, BoolVariable, PathVariable, ListVariable
 
 __all__ = ['Variables', 'EnumVariable', 'BoolVariable', 'PathVariable', 'ListVariable']

--- a/tools/cmakeconverter/SCons/__init__.py
+++ b/tools/cmakeconverter/SCons/__init__.py
@@ -1,2 +1,19 @@
 """Mock SCons package"""
-from mock_scons import __version__
+from . import Script
+from . import Util
+from . import Variables
+
+# Export commonly used items
+from .Script import (
+    Variables, EnumVariable, BoolVariable, PathVariable, ListVariable,
+    Action, Builder, Program, StaticLibrary, SharedLibrary, Object,
+    ARGUMENTS, COMMAND_LINE_TARGETS, BUILD_TARGETS, DEFAULT_TARGETS,
+    GetOption, SetOption, AddOption, GetBuildFailures, Progress, Exit
+)
+from .Util import (
+    WhereIs, is_String, is_List, is_Dict,
+    flatten, to_String, to_List, to_Dict
+)
+
+# Version information
+__version__ = "4.0.0"

--- a/tools/cmakeconverter/cmake_generator.py
+++ b/tools/cmakeconverter/cmake_generator.py
@@ -18,7 +18,10 @@ class CMakeTarget:
 
     def add_sources(self, sources: List[str]):
         """Add source files to the target"""
-        self.sources.extend(sources)
+        for src in sources:
+            if not os.path.isabs(src):
+                src = "${CMAKE_SOURCE_DIR}/" + src
+            self.sources.append(src)
 
     def add_include_dirs(self, dirs: List[str]):
         """Add include directories"""
@@ -290,13 +293,15 @@ class GodotCMakeGenerator:
         cmake_content = self.project.generate()
         
         # Write the main CMakeLists.txt
-        os.makedirs(os.path.dirname(output_path), exist_ok=True)
+        output_dir = os.path.dirname(output_path)
+        if output_dir:  # Only create directory if path has a directory part
+            os.makedirs(output_dir, exist_ok=True)
         with open(output_path, "w") as f:
             f.write(cmake_content)
 
         # Generate module CMakeLists.txt files
         for module in self.enabled_modules:
-            module_path = f"modules/{module}/CMakeLists.txt"
+            module_path = os.path.join(os.path.dirname(output_path), "modules", module, "CMakeLists.txt")
             module_content = self._generate_module_cmake(module)
             os.makedirs(os.path.dirname(module_path), exist_ok=True)
             with open(module_path, "w") as f:

--- a/tools/cmakeconverter/interpreter/__init__.py
+++ b/tools/cmakeconverter/interpreter/__init__.py
@@ -8,6 +8,9 @@ from .base import (
     EnsureSConsVersion, EnsurePythonVersion,
     Node, FileNode, DirNode
 )
+from .functions import Glob, Value, Run, CommandNoCache
+from . import detect
+from . import platform
 from .environment import SConsEnvironment
 from .variables import Variable, EnumVariable, BoolVariable, PathVariable, ListVariable, Variables
 from .builders import Action, Builder, Program, StaticLibrary, SharedLibrary, Object
@@ -26,6 +29,8 @@ class SConsInterpreter:
         self.current_script_dir = ""
         self.project_root = project_root
         self._dict = {}
+        self._variant_dir = None  # Current variant directory
+        self._default_env_instance = None  # Singleton instance for DefaultEnvironment()
         
         if project_root:
             # Add project root to Python path for imports
@@ -38,6 +43,78 @@ class SConsInterpreter:
             'BUILD_DIR': 'build',
             'ENV': os.environ.copy(),
         })
+        
+    def _create_global_namespace(self, env: Optional[SConsEnvironment] = None) -> Dict[str, Any]:
+        """Create a new global namespace for script execution"""
+        opts = Variables()
+        
+        if env is None:
+            env = self.default_env
+            
+        if self._default_env_instance is None:
+            self._default_env_instance = SConsEnvironment()
+            
+        def Return(*args):
+            """Store return value in global namespace"""
+            if len(args) == 1:
+                global_dict['__return_value__'] = args[0]
+            elif len(args) > 1:
+                global_dict['__return_value__'] = args
+            
+        # Import SCons module
+        from tools.cmakeconverter import SCons
+        
+        global_dict = {
+            'env': env,
+            'Environment': self.Environment,
+            'ARGUMENTS': self.variables.get('ARGUMENTS', {}),
+            'COMMAND_LINE_TARGETS': self.variables.get('COMMAND_LINE_TARGETS', []),
+            'DefaultEnvironment': lambda: self._default_env_instance,
+            'Export': self.Export,
+            'Import': self.Import,
+            'SConscript': self.SConscript,
+            'Return': Return,  # Add Return function
+            'EnsureSConsVersion': EnsureSConsVersion,
+            'EnsurePythonVersion': EnsurePythonVersion,
+            'Variables': lambda *args: opts,  # Return the same instance
+            'EnumVariable': EnumVariable,
+            'BoolVariable': BoolVariable,
+            'PathVariable': PathVariable,
+            'ListVariable': ListVariable,
+            'File': lambda x: FileNode(x),
+            'Dir': lambda x: DirNode(x),
+            'Action': Action,
+            'Builder': Builder,
+            'Program': Program,
+            'StaticLibrary': StaticLibrary,
+            'SharedLibrary': SharedLibrary,
+            'Object': Object,
+            'WhereIs': WhereIs,
+            'Help': lambda x: None,  # We don't need to process help text for CMake
+            'SCons': SCons,  # Add SCons module
+            'Glob': Glob,  # Add Glob function
+            'Value': Value,  # Add Value function
+            'Run': Run,  # Add Run function
+            'CommandNoCache': CommandNoCache,  # Add CommandNoCache function
+            'detect': detect,  # Add detect module
+            'platform_list': platform.platform_list,  # Add platform variables
+            'platform_opts': platform.platform_opts,
+            'platform_flags': platform.platform_flags,
+            'platform_doc_class_path': platform.platform_doc_class_path,
+            'platform_exporters': platform.platform_exporters,
+            'platform_apis': platform.platform_apis,
+            'sys': sys,  # Add sys module
+            'os': os,  # Add os module
+            'glob': __import__('glob'),  # Add glob module
+            'OrderedDict': __import__('collections').OrderedDict,  # Add OrderedDict
+            'pickle': __import__('pickle'),  # Add pickle module
+            'ModuleType': __import__('types').ModuleType,  # Add ModuleType
+            'module_from_spec': __import__('importlib.util').module_from_spec,  # Add module_from_spec
+            'spec_from_file_location': __import__('importlib.util').spec_from_file_location,  # Add spec_from_file_location
+            '_helper_module': lambda name, path: None,  # Mock _helper_module function
+        }
+        print(f"DEBUG: Global namespace created with keys: {list(global_dict.keys())}")
+        return global_dict
         
     def Environment(self, **kwargs) -> SConsEnvironment:
         """Create a new construction environment"""
@@ -58,42 +135,22 @@ class SConsInterpreter:
     def interpret_file(self, filepath: str) -> None:
         """Interpret a SCons script file"""
         try:
+            prev_dir = self.current_script_dir
             self.current_script_dir = os.path.dirname(filepath)
+            
+            # Add SCons module to Python path
+            converter_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+            if converter_root not in sys.path:
+                sys.path.insert(0, converter_root)
+            
             with open(filepath, 'r') as f:
                 content = f.read()
             
-            # Create a new global namespace for execution
-            opts = Variables()
-            
-            global_dict = {
-                'Environment': self.Environment,
-                'ARGUMENTS': self.variables.get('ARGUMENTS', {}),
-                'COMMAND_LINE_TARGETS': self.variables.get('COMMAND_LINE_TARGETS', []),
-                'DefaultEnvironment': lambda: self.default_env,
-                'Export': self.Export,
-                'Import': self.Import,
-                'SConscript': self.SConscript,
-                'EnsureSConsVersion': EnsureSConsVersion,
-                'EnsurePythonVersion': EnsurePythonVersion,
-                'Variables': lambda *args: opts,  # Return the same instance
-                'EnumVariable': EnumVariable,
-                'BoolVariable': BoolVariable,
-                'PathVariable': PathVariable,
-                'ListVariable': ListVariable,
-                'File': lambda x: FileNode(x),
-                'Dir': lambda x: DirNode(x),
-                'Action': Action,
-                'Builder': Builder,
-                'Program': Program,
-                'StaticLibrary': StaticLibrary,
-                'SharedLibrary': SharedLibrary,
-                'Object': Object,
-                'WhereIs': WhereIs,
-                'Help': lambda x: None,  # We don't need to process help text for CMake
-            }
-            
             # Execute the SCons script
+            global_dict = self._create_global_namespace()
             exec(content, global_dict)
+            
+            self.current_script_dir = prev_dir
             
         except Exception as e:
             import traceback
@@ -141,11 +198,17 @@ class SConsInterpreter:
         else:
             raise SConsError("Unsupported Import() format")
     
-    def SConscript(self, scripts, *args, **kwargs):
+    def SConscript(self, scripts, *args, **kwargs) -> Any:
         """Process subsidiary SConscript files"""
         if isinstance(scripts, str):
             scripts = [scripts]
-        
+            
+        # Get variant directory
+        variant_dir = kwargs.get('variant_dir')
+        if variant_dir:
+            prev_variant_dir = self._variant_dir
+            self._variant_dir = variant_dir
+            
         # Get exports from kwargs
         exports = kwargs.get('exports', [])
         if isinstance(exports, str):
@@ -161,44 +224,43 @@ class SConsInterpreter:
                 self.variables[f"exported_{var}"] = self._dict[var]
             else:
                 self.variables[f"exported_{var}"] = None
-        
+                
+        # Process each script
+        results = []
         for script in scripts:
             script_path = os.path.join(self.current_script_dir, script)
             if not os.path.exists(script_path):
                 raise SConsError(f"SConscript file not found: {script_path}")
+                
+            # Save current directory
+            prev_dir = self.current_script_dir
+            self.current_script_dir = os.path.dirname(script_path)
             
             # Create a new global namespace for the script
-            opts = Variables()
-            
-            global_dict = {
-                'env': self.default_env,
-                'Environment': self.Environment,
-                'ARGUMENTS': self.variables.get('ARGUMENTS', {}),
-                'COMMAND_LINE_TARGETS': self.variables.get('COMMAND_LINE_TARGETS', []),
-                'DefaultEnvironment': lambda: self.default_env,
-                'Export': self.Export,
-                'Import': self.Import,
-                'SConscript': self.SConscript,
-                'EnsureSConsVersion': EnsureSConsVersion,
-                'EnsurePythonVersion': EnsurePythonVersion,
-                'Variables': lambda *args: opts,  # Return the same instance
-                'EnumVariable': EnumVariable,
-                'BoolVariable': BoolVariable,
-                'PathVariable': PathVariable,
-                'ListVariable': ListVariable,
-                'File': lambda x: FileNode(x),
-                'Dir': lambda x: DirNode(x),
-                'Action': Action,
-                'Builder': Builder,
-                'Program': Program,
-                'StaticLibrary': StaticLibrary,
-                'SharedLibrary': SharedLibrary,
-                'Object': Object,
-                'WhereIs': WhereIs,
-                'Help': lambda x: None,  # We don't need to process help text for CMake
-            }
+            global_dict = self._create_global_namespace()
             
             # Execute the script
             with open(script_path, 'r') as f:
                 content = f.read()
             exec(content, global_dict)
+            
+            # Check for Return value
+            if 'Return' in content:
+                result = global_dict.get('__return_value__')
+                if result is not None:
+                    results.append(result)
+                
+            # Restore current directory
+            self.current_script_dir = prev_dir
+            
+        # Restore variant directory
+        if variant_dir:
+            self._variant_dir = prev_variant_dir
+            
+        # Return results
+        if not results:
+            return None
+        elif len(results) == 1:
+            return results[0]
+        else:
+            return results

--- a/tools/cmakeconverter/interpreter/builders.py
+++ b/tools/cmakeconverter/interpreter/builders.py
@@ -61,6 +61,26 @@ class Program(Builder):
     """Builder for executable programs"""
     def __init__(self, **kwargs):
         super().__init__(suffix='.exe' if sys.platform == 'win32' else '', **kwargs)
+        
+    def __call__(self, env: Any, target: Union[str, List[str]], 
+                 source: Optional[Union[str, List[str]]] = None, **kwargs) -> List[Node]:
+        """Build the target"""
+        if isinstance(target, str):
+            target = [target]
+        if isinstance(source, str):
+            source = [source]
+            
+        # Convert targets and sources to nodes
+        target_nodes = [FileNode(t) for t in target]
+        source_nodes = [FileNode(s) for s in (source or [])]
+        
+        # Execute the action if one exists
+        if self.action:
+            result = self.action(target_nodes, source_nodes, env)
+            if result != 0:
+                raise SConsError(f"Builder action failed with code {result}")
+                
+        return target_nodes
 
 class StaticLibrary(Builder):
     """Builder for static libraries"""

--- a/tools/cmakeconverter/interpreter/detect.py
+++ b/tools/cmakeconverter/interpreter/detect.py
@@ -1,0 +1,25 @@
+"""Mock detect module for platform detection"""
+
+def get_name():
+    """Get platform name"""
+    return "LinuxBSD"
+
+def can_build():
+    """Check if platform can be built"""
+    return True
+
+def get_opts():
+    """Get platform options"""
+    return []
+
+def get_flags():
+    """Get platform flags"""
+    return []
+
+def get_doc_classes():
+    """Get platform documentation classes"""
+    return []
+
+def get_doc_path():
+    """Get platform documentation path"""
+    return ""

--- a/tools/cmakeconverter/interpreter/functions.py
+++ b/tools/cmakeconverter/interpreter/functions.py
@@ -1,0 +1,29 @@
+"""Additional SCons functions"""
+
+def Glob(pattern):
+    """Glob files"""
+    print(f"DEBUG: Glob called with pattern={pattern}")
+    import glob
+    import os
+    if pattern.startswith('#'):
+        pattern = pattern[1:]  # Remove the # prefix
+    if not pattern.startswith('/'):
+        pattern = os.path.join(os.getcwd(), pattern)
+    result = glob.glob(pattern)
+    print(f"DEBUG: Glob result: {result}")
+    return result
+
+def Value(value):
+    """Create a Value node"""
+    print(f"DEBUG: Value called with value={value}")
+    return value
+
+def Run(command):
+    """Run a command"""
+    print(f"DEBUG: Run called with command={command}")
+    return command
+
+def CommandNoCache(target, source, action):
+    """Run a command without caching"""
+    print(f"DEBUG: CommandNoCache called with target={target}, source={source}, action={action}")
+    return None

--- a/tools/cmakeconverter/interpreter/methods.py
+++ b/tools/cmakeconverter/interpreter/methods.py
@@ -1,0 +1,33 @@
+"""Helper methods for SCons interpreter"""
+from contextlib import contextmanager
+import os
+from io import StringIO, TextIOBase
+from typing import Generator, Optional
+
+@contextmanager
+def generated_wrapper(
+    target,
+    guard: Optional[bool] = None,
+    prefix: str = "",
+    suffix: str = "",
+) -> Generator[TextIOBase, None, None]:
+    """Context manager for generating files"""
+    if isinstance(target, list):
+        target = target[0]
+    if isinstance(target, str):
+        os.makedirs(os.path.dirname(target), exist_ok=True)
+        with open(target, 'w') as f:
+            f.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
+            if guard:
+                guard_name = os.path.basename(target).replace(".", "_").upper()
+                if prefix:
+                    guard_name = prefix + "_" + guard_name
+                if suffix:
+                    guard_name = guard_name + "_" + suffix
+                f.write(f"#ifndef {guard_name}\n")
+                f.write(f"#define {guard_name}\n\n")
+            yield f
+            if guard:
+                f.write(f"\n#endif // {guard_name}\n")
+    else:
+        yield target

--- a/tools/cmakeconverter/interpreter/platform.py
+++ b/tools/cmakeconverter/interpreter/platform.py
@@ -1,0 +1,8 @@
+"""Platform detection module"""
+
+platform_list = []  # list of platforms
+platform_opts = {}  # options for each platform
+platform_flags = {}  # flags for each platform
+platform_doc_class_path = {}  # documentation paths
+platform_exporters = []  # platform exporters
+platform_apis = []  # platform APIs


### PR DESCRIPTION
This commit adds a new tool to convert the Godot build system from SCons to CMake. The tool is still in development but provides the basic structure for:

- SCons environment simulation
- Variable handling
- Platform detection
- Basic file operations
- Module loading framework

Current features:
- Basic SCons interpreter
- Variable and environment handling
- Platform detection structure
- File operations (Glob, Object, etc.)
- Initial CMake output framework

This is part of the effort to provide alternative build system options for Godot engine.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
