### PR TITLE
Add SCons to CMake converter interpreter modules

### DIFF
--- a/tools/cmakeconverter/cmake_generator.py
+++ b/tools/cmakeconverter/cmake_generator.py
@@ -1,324 +1,125 @@
-"""CMake project generator for Godot"""
-from typing import Any, Dict, List, Optional, Set
-import os
-import textwrap
+"""CMake generator module for SCons to CMake converter"""
+from typing import Any, Dict, List, Optional, Union
 
-class CMakeTarget:
-    """Represents a CMake target (executable, library, etc.)"""
-    def __init__(self, name: str, target_type: str):
-        self.name = name
-        self.type = target_type  # executable, library, etc.
-        self.sources: List[str] = []
-        self.include_dirs: Set[str] = set()
-        self.compile_definitions: Set[str] = set()
-        self.compile_options: Set[str] = set()
-        self.link_libraries: Set[str] = set()
-        self.link_options: Set[str] = set()
-        self.dependencies: Set[str] = set()
+class CMakeGenerator:
+    """CMake generator class"""
+    def __init__(self) -> None:
+        self.cmake_minimum_version = "3.20"
+        self.project_name = "godot"
+        self.project_version = "4.4.0"
+        self.project_languages = ["C", "CXX"]
+        self.variables = {}
+        self.targets = {}
+        self.dependencies = {}
+        self.options = {}
 
-    def add_sources(self, sources: List[str]):
-        """Add source files to the target"""
-        for src in sources:
-            if not os.path.isabs(src):
-                src = "${CMAKE_SOURCE_DIR}/" + src
-            self.sources.append(src)
-
-    def add_include_dirs(self, dirs: List[str]):
-        """Add include directories"""
-        self.include_dirs.update(dirs)
-
-    def add_definitions(self, defs: List[str]):
-        """Add compile definitions"""
-        self.compile_definitions.update(defs)
-
-    def add_compile_options(self, options: List[str]):
-        """Add compile options"""
-        self.compile_options.update(options)
-
-    def add_link_libraries(self, libs: List[str]):
-        """Add libraries to link against"""
-        self.link_libraries.update(libs)
-
-    def add_link_options(self, options: List[str]):
-        """Add linker options"""
-        self.link_options.update(options)
-
-    def add_dependencies(self, deps: List[str]):
-        """Add target dependencies"""
-        self.dependencies.update(deps)
-
-    def generate(self, indent: int = 0) -> str:
-        """Generate CMake code for this target"""
-        ind = " " * indent
-        lines = []
-
-        # Target declaration
-        if self.type == "executable":
-            lines.append(f"{ind}add_executable({self.name}")
-        elif self.type == "shared":
-            lines.append(f"{ind}add_library({self.name} SHARED")
-        elif self.type == "static":
-            lines.append(f"{ind}add_library({self.name} STATIC")
-        else:
-            lines.append(f"{ind}add_library({self.name} {self.type}")
-
-        # Sources
-        if self.sources:
-            lines.append(f"{ind}    {' '.join(sorted(self.sources))}")
-        lines.append(f"{ind})")
-
-        # Include directories
-        if self.include_dirs:
-            lines.append(f"{ind}target_include_directories({self.name} PUBLIC")
-            for inc in sorted(self.include_dirs):
-                lines.append(f"{ind}    {inc}")
-            lines.append(f"{ind})")
-
-        # Compile definitions
-        if self.compile_definitions:
-            lines.append(f"{ind}target_compile_definitions({self.name} PUBLIC")
-            for define in sorted(self.compile_definitions):
-                lines.append(f"{ind}    {define}")
-            lines.append(f"{ind})")
-
-        # Compile options
-        if self.compile_options:
-            lines.append(f"{ind}target_compile_options({self.name} PUBLIC")
-            for opt in sorted(self.compile_options):
-                lines.append(f"{ind}    {opt}")
-            lines.append(f"{ind})")
-
-        # Link libraries
-        if self.link_libraries:
-            lines.append(f"{ind}target_link_libraries({self.name} PUBLIC")
-            for lib in sorted(self.link_libraries):
-                lines.append(f"{ind}    {lib}")
-            lines.append(f"{ind})")
-
-        # Link options
-        if self.link_options:
-            lines.append(f"{ind}target_link_options({self.name} PUBLIC")
-            for opt in sorted(self.link_options):
-                lines.append(f"{ind}    {opt}")
-            lines.append(f"{ind})")
-
-        # Dependencies
-        if self.dependencies:
-            lines.append(f"{ind}add_dependencies({self.name}")
-            for dep in sorted(self.dependencies):
-                lines.append(f"{ind}    {dep}")
-            lines.append(f"{ind})")
-
-        return "\n".join(lines)
-
-class CMakeProject:
-    """Represents a CMake project"""
-    def __init__(self, name: str, version: str = "1.0.0"):
-        self.name = name
-        self.version = version
-        self.minimum_version = "3.16"
-        self.targets: Dict[str, CMakeTarget] = {}
-        self.variables: Dict[str, Any] = {}
-        self.options: Dict[str, Any] = {}
-        self.custom_commands: List[str] = []
-        self.custom_targets: List[str] = []
-        self.includes: List[str] = []
-
-    def add_target(self, name: str, target_type: str) -> CMakeTarget:
-        """Add a new target to the project"""
-        target = CMakeTarget(name, target_type)
-        self.targets[name] = target
-        return target
-
-    def set_variable(self, name: str, value: Any):
-        """Set a CMake variable"""
-        self.variables[name] = value
-
-    def add_option(self, name: str, description: str, default_value: Any):
-        """Add a CMake option"""
-        self.options[name] = {
-            "description": description,
-            "default": default_value
+    def add_variable(self, name: str, value: Any, type: str = None) -> None:
+        """Add CMake variable"""
+        self.variables[name] = {
+            "value": value,
+            "type": type
         }
 
-    def add_custom_command(self, command: str):
-        """Add a custom CMake command"""
-        self.custom_commands.append(command)
+    def add_target(self, name: str, type: str, sources: List[str], includes: List[str] = None, 
+                  defines: List[str] = None, options: Dict[str, Any] = None) -> None:
+        """Add CMake target"""
+        self.targets[name] = {
+            "type": type,
+            "sources": sources,
+            "includes": includes or [],
+            "defines": defines or [],
+            "options": options or {}
+        }
 
-    def add_custom_target(self, target: str):
-        """Add a custom CMake target"""
-        self.custom_targets.append(target)
+    def add_dependency(self, target: str, dependency: str) -> None:
+        """Add target dependency"""
+        if target not in self.dependencies:
+            self.dependencies[target] = []
+        self.dependencies[target].append(dependency)
 
-    def add_include(self, path: str):
-        """Add a CMake include directive"""
-        self.includes.append(path)
+    def add_option(self, name: str, description: str, default: Any, type: str = None) -> None:
+        """Add CMake option"""
+        self.options[name] = {
+            "description": description,
+            "default": default,
+            "type": type
+        }
 
-    def generate(self) -> str:
-        """Generate the complete CMake project"""
-        lines = []
+    def generate(self, output_file: str) -> None:
+        """Generate CMakeLists.txt"""
+        with open(output_file, "w", encoding="utf-8", newline="\n") as f:
+            # Write CMake minimum version
+            f.write(f"cmake_minimum_required(VERSION {self.cmake_minimum_version})\n\n")
 
-        # Header
-        lines.append(f"cmake_minimum_required(VERSION {self.minimum_version})")
-        lines.append(f"project({self.name} VERSION {self.version})")
-        lines.append("")
+            # Write project declaration
+            f.write(f"project({self.project_name}\n")
+            f.write(f"    VERSION {self.project_version}\n")
+            f.write(f"    LANGUAGES {' '.join(self.project_languages)}\n")
+            f.write(")\n\n")
 
-        # Options
-        if self.options:
-            lines.append("# Options")
-            for name, opt in self.options.items():
-                lines.append(f'option({name} "{opt["description"]}" {opt["default"]})')
-            lines.append("")
+            # Write options
+            if self.options:
+                f.write("# Options\n")
+                for name, option in self.options.items():
+                    if option["type"]:
+                        f.write(f"option({name} \"{option['description']}\" {option['default']} TYPE {option['type']})\n")
+                    else:
+                        f.write(f"option({name} \"{option['description']}\" {option['default']})\n")
+                f.write("\n")
 
-        # Variables
-        if self.variables:
-            lines.append("# Variables")
-            for name, value in self.variables.items():
-                if isinstance(value, (list, tuple, set)):
-                    lines.append(f"set({name}")
-                    for item in value:
-                        lines.append(f"    {item}")
-                    lines.append(")")
-                else:
-                    lines.append(f"set({name} {value})")
-            lines.append("")
+            # Write variables
+            if self.variables:
+                f.write("# Variables\n")
+                for name, var in self.variables.items():
+                    if var["type"]:
+                        f.write(f"set({name} {var['value']} TYPE {var['type']})\n")
+                    else:
+                        f.write(f"set({name} {var['value']})\n")
+                f.write("\n")
 
-        # Includes
-        if self.includes:
-            lines.append("# Includes")
-            for inc in self.includes:
-                lines.append(f"include({inc})")
-            lines.append("")
+            # Write targets
+            if self.targets:
+                f.write("# Targets\n")
+                for name, target in self.targets.items():
+                    if target["type"] == "executable":
+                        f.write(f"add_executable({name}\n")
+                    elif target["type"] == "static":
+                        f.write(f"add_library({name} STATIC\n")
+                    elif target["type"] == "shared":
+                        f.write(f"add_library({name} SHARED\n")
+                    else:
+                        f.write(f"add_library({name} MODULE\n")
 
-        # Custom commands
-        if self.custom_commands:
-            lines.append("# Custom commands")
-            for cmd in self.custom_commands:
-                lines.append(cmd)
-            lines.append("")
+                    # Write sources
+                    for source in target["sources"]:
+                        f.write(f"    {source}\n")
+                    f.write(")\n")
 
-        # Custom targets
-        if self.custom_targets:
-            lines.append("# Custom targets")
-            for target in self.custom_targets:
-                lines.append(target)
-            lines.append("")
+                    # Write includes
+                    if target["includes"]:
+                        f.write(f"target_include_directories({name} PRIVATE\n")
+                        for include in target["includes"]:
+                            f.write(f"    {include}\n")
+                        f.write(")\n")
 
-        # Targets
-        if self.targets:
-            lines.append("# Targets")
-            for target in self.targets.values():
-                lines.append(target.generate(indent=0))
-                lines.append("")
+                    # Write defines
+                    if target["defines"]:
+                        f.write(f"target_compile_definitions({name} PRIVATE\n")
+                        for define in target["defines"]:
+                            f.write(f"    {define}\n")
+                        f.write(")\n")
 
-        return "\n".join(lines)
+                    # Write options
+                    if target["options"]:
+                        for option_name, option_value in target["options"].items():
+                            f.write(f"set_target_properties({name} PROPERTIES {option_name} {option_value})\n")
 
-class GodotCMakeGenerator:
-    """Generates CMake project from Godot's SCons configuration"""
-    def __init__(self):
-        self.project = CMakeProject("godot")
-        self.platform_defines: Dict[str, List[str]] = {}
-        self.platform_flags: Dict[str, List[str]] = {}
-        self.enabled_modules: Set[str] = set()
+                    f.write("\n")
 
-    def process_variables(self, variables: Dict[str, Any]):
-        """Process SCons variables into CMake options/variables"""
-        for name, value in variables.items():
-            if isinstance(value, bool):
-                # Convert boolean SCons variables to CMake options
-                self.project.add_option(
-                    name=name.upper(),
-                    description=f"Enable {name}",
-                    default_value="ON" if value else "OFF"
-                )
-            elif isinstance(value, (str, int, float)):
-                # Convert scalar SCons variables to CMake variables
-                self.project.set_variable(name.upper(), value)
-            elif isinstance(value, (list, tuple)):
-                # Convert list SCons variables to CMake list variables
-                self.project.set_variable(name.upper(), ";".join(str(x) for x in value))
-
-    def process_environment(self, env: Dict[str, Any]):
-        """Process SCons environment into CMake configuration"""
-        # Process compiler flags
-        if "CCFLAGS" in env:
-            self.project.set_variable("CMAKE_C_FLAGS", " ".join(env["CCFLAGS"]))
-            self.project.set_variable("CMAKE_CXX_FLAGS", " ".join(env["CCFLAGS"]))
-
-        if "CXXFLAGS" in env:
-            self.project.set_variable("CMAKE_CXX_FLAGS", " ".join(env["CXXFLAGS"]))
-
-        if "LINKFLAGS" in env:
-            self.project.set_variable("CMAKE_EXE_LINKER_FLAGS", " ".join(env["LINKFLAGS"]))
-            self.project.set_variable("CMAKE_SHARED_LINKER_FLAGS", " ".join(env["LINKFLAGS"]))
-
-        # Process include paths
-        if "CPPPATH" in env:
-            includes = [f"${{CMAKE_SOURCE_DIR}}/{path}" for path in env["CPPPATH"]]
-            self.project.set_variable("GODOT_INCLUDE_DIRS", includes)
-
-        # Process defines
-        if "CPPDEFINES" in env:
-            defines = []
-            for define in env["CPPDEFINES"]:
-                if isinstance(define, tuple):
-                    defines.append(f"{define[0]}={define[1]}")
-                else:
-                    defines.append(str(define))
-            self.project.set_variable("GODOT_DEFINES", defines)
-
-    def process_modules(self, modules: List[str]):
-        """Process Godot modules into CMake targets"""
-        for module in modules:
-            target = self.project.add_target(f"godot_{module}", "static")
-            target.add_compile_definitions([f"MODULE_{module.upper()}_ENABLED"])
-            self.enabled_modules.add(module)
-
-    def process_platform(self, platform: str):
-        """Process platform-specific configuration"""
-        if platform in self.platform_defines:
-            self.project.set_variable(
-                f"GODOT_{platform.upper()}_DEFINES",
-                self.platform_defines[platform]
-            )
-
-        if platform in self.platform_flags:
-            self.project.set_variable(
-                f"GODOT_{platform.upper()}_FLAGS",
-                self.platform_flags[platform]
-            )
-
-    def generate(self, output_path: str):
-        """Generate the CMake project files"""
-        # Main CMakeLists.txt
-        cmake_content = self.project.generate()
-        
-        # Write the main CMakeLists.txt
-        output_dir = os.path.dirname(output_path)
-        if output_dir:  # Only create directory if path has a directory part
-            os.makedirs(output_dir, exist_ok=True)
-        with open(output_path, "w") as f:
-            f.write(cmake_content)
-
-        # Generate module CMakeLists.txt files
-        for module in self.enabled_modules:
-            module_path = os.path.join(os.path.dirname(output_path), "modules", module, "CMakeLists.txt")
-            module_content = self._generate_module_cmake(module)
-            os.makedirs(os.path.dirname(module_path), exist_ok=True)
-            with open(module_path, "w") as f:
-                f.write(module_content)
-
-    def _generate_module_cmake(self, module: str) -> str:
-        """Generate CMakeLists.txt for a specific module"""
-        lines = []
-        lines.append(f"# CMakeLists.txt for module {module}")
-        lines.append("")
-        lines.append(f"target_sources(godot_{module}")
-        lines.append("    PRIVATE")
-        lines.append("        ${MODULE_SOURCES}")  # Placeholder
-        lines.append(")")
-        lines.append("")
-        lines.append("target_include_directories(godot_{module}")
-        lines.append("    PUBLIC")
-        lines.append("        ${CMAKE_CURRENT_SOURCE_DIR}")
-        lines.append(")")
-        return "\n".join(lines)
+            # Write dependencies
+            if self.dependencies:
+                f.write("# Dependencies\n")
+                for target, deps in self.dependencies.items():
+                    for dep in deps:
+                        f.write(f"add_dependencies({target} {dep})\n")
+                f.write("\n")

--- a/tools/cmakeconverter/converter.py
+++ b/tools/cmakeconverter/converter.py
@@ -1,150 +1,76 @@
-"""Convert Godot's SCons build system to CMake"""
+"""SCons to CMake converter module"""
 import os
-import sys
-from typing import Any, Dict, List, Optional
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
 
-from .interpreter import SConsInterpreter, SConsError
-from .cmake_generator import GodotCMakeGenerator
+from .cmake_generator import CMakeGenerator
+from .interpreter import SConsInterpreter
 
-class BuildSystemConverter:
-    """Converts SCons build system to CMake"""
-    def __init__(self):
-        self.interpreter = SConsInterpreter()
-        self.cmake_generator = GodotCMakeGenerator()
-        self.scons_vars: Dict[str, Any] = {}
-        self.scons_env: Dict[str, Any] = {}
-        self.platform = ""
-        self.modules: List[str] = []
-
-    def process_scons(self, sconstruct_path: str):
-        """Process the SCons build system"""
-        try:
-            # Create interpreter with project root
-            project_root = os.path.dirname(os.path.abspath(sconstruct_path))
-            converter_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-            
-            # Add project root and converter root to Python path
-            if project_root not in sys.path:
-                sys.path.insert(0, project_root)
-            if converter_root not in sys.path:
-                sys.path.insert(0, converter_root)
-                
-            self.interpreter = SConsInterpreter(project_root=project_root)
-
-            # Parse SCons configuration
-            self.interpreter.interpret_file(sconstruct_path)
-
-            # Extract variables
-            self.scons_vars = self.interpreter.variables
-            
-            # Get default environment
-            env = self.interpreter.default_env
-            self.scons_env = env.variables.copy()
-            self.scons_env.update({
-                'CCFLAGS': env.get('CCFLAGS', []),
-                'CXXFLAGS': env.get('CXXFLAGS', []),
-                'LINKFLAGS': env.get('LINKFLAGS', []),
-                'CPPPATH': env.get('CPPPATH', []),
-                'CPPDEFINES': env.get('CPPDEFINES', []),
-                'LIBS': env.get('LIBS', []),
-                'LIBPATH': env.get('LIBPATH', []),
-            })
-
-            # Get platform
-            self.platform = self.scons_vars.get('platform', 'linuxbsd')
-
-            # Get modules
-            self.modules = self._detect_modules()
-
-        except SConsError as e:
-            print(f"Error processing SCons: {e}")
-            raise
-
-    def _detect_modules(self) -> List[str]:
-        """Detect available and enabled Godot modules"""
-        modules = []
-        
-        # First check enabled modules from variables
-        for key, value in self.scons_vars.items():
-            if key.startswith('module_') and key.endswith('_enabled'):
-                if value:
-                    module = key[7:-8]  # Remove 'module_' prefix and '_enabled' suffix
-                    modules.append(module)
-        
-        # Then check for modules with SCsub files
-        if not modules:  # Only if no modules were found in variables
-            modules_path = os.path.join(os.path.dirname(self.interpreter.current_script_dir), "modules")
-            if os.path.exists(modules_path):
-                for item in os.listdir(modules_path):
-                    if os.path.isdir(os.path.join(modules_path, item)):
-                        # Check if it's a valid module (has a SCons file)
-                        if os.path.exists(os.path.join(modules_path, item, "SCsub")):
-                            modules.append(item)
-        
-        return modules
-
-    def generate_cmake(self, output_path: str):
-        """Generate CMake project"""
-        try:
-            # Process variables
-            self.cmake_generator.process_variables(self.scons_vars)
-
-            # Process environment
-            self.cmake_generator.process_environment(self.scons_env)
-
-            # Process modules
-            self.cmake_generator.process_modules(self.modules)
-
-            # Process platform
-            if self.platform:
-                self.cmake_generator.process_platform(self.platform)
-
-            # Process builders
-            for builder in self.interpreter.default_env.builders:
-                if builder['type'] == 'program':
-                    target = self.cmake_generator.project.add_target(
-                        name=builder['target'][0],
-                        target_type='executable'
-                    )
-                    target.add_sources(builder['source'])
-                    if 'include_dirs' in builder:
-                        target.add_include_dirs(builder['include_dirs'])
-                    if 'compile_flags' in builder:
-                        target.add_compile_options(builder['compile_flags'])
-                    if 'link_flags' in builder:
-                        target.add_link_options(builder['link_flags'])
-                    if 'libraries' in builder:
-                        target.add_link_libraries(builder['libraries'])
-                elif builder['type'] == 'library':
-                    target = self.cmake_generator.project.add_target(
-                        name=builder['target'][0],
-                        target_type='shared' if builder.get('shared', False) else 'static'
-                    )
-                    target.add_sources(builder['source'])
-                    if 'include_dirs' in builder:
-                        target.add_include_dirs(builder['include_dirs'])
-                    if 'compile_flags' in builder:
-                        target.add_compile_options(builder['compile_flags'])
-                    if 'link_flags' in builder:
-                        target.add_link_options(builder['link_flags'])
-                    if 'libraries' in builder:
-                        target.add_link_libraries(builder['libraries'])
-
-            # Generate CMake files
-            self.cmake_generator.generate(output_path)
-
-        except Exception as e:
-            print(f"Error generating CMake: {e}")
-            raise
-
-def convert_build_system(sconstruct_path: str, output_path: str):
+def convert_build_system(sconstruct_path: str) -> None:
     """Convert SCons build system to CMake"""
-    converter = BuildSystemConverter()
-    
-    print("Processing SCons build system...")
-    converter.process_scons(sconstruct_path)
-    
-    print("Generating CMake project...")
-    converter.generate_cmake(output_path)
-    
-    print("Conversion complete!")
+    print("Starting conversion from", os.path.basename(sconstruct_path))
+    print("Current working directory:", os.getcwd())
+
+    # Get absolute path to SConstruct file
+    abs_sconstruct = os.path.abspath(sconstruct_path)
+    print("Looking for SConstruct at:", abs_sconstruct)
+
+    # Get output path
+    output_path = os.path.join(os.path.dirname(abs_sconstruct), "CMakeLists.txt")
+    print("Output will be written to:", output_path)
+
+    # Create converter
+    converter = SConsConverter()
+
+    try:
+        # Process SCons build system
+        print("Processing SCons build system...")
+        converter.process_scons(abs_sconstruct)
+
+        # Generate CMake build system
+        print("Generating CMake build system...")
+        converter.generate_cmake(output_path)
+
+        print("Conversion complete!")
+
+    except Exception as e:
+        print("Error during conversion:", str(e))
+        print("Traceback:")
+        import traceback
+        traceback.print_exc()
+        raise
+
+class SConsConverter:
+    """SCons to CMake converter class"""
+    def __init__(self) -> None:
+        self.interpreter = SConsInterpreter()
+        self.generator = CMakeGenerator()
+
+    def process_scons(self, sconstruct_path: str) -> None:
+        """Process SCons build system"""
+        self.interpreter.interpret_file(sconstruct_path)
+
+    def generate_cmake(self, output_path: str) -> None:
+        """Generate CMake build system"""
+        # Convert SCons variables to CMake variables
+        for name, value in self.interpreter.variables.items():
+            self.generator.add_variable(name, value)
+
+        # Convert SCons targets to CMake targets
+        for name, target in self.interpreter.targets.items():
+            self.generator.add_target(
+                name=name,
+                type=target["type"],
+                sources=target["sources"],
+                includes=target.get("includes"),
+                defines=target.get("defines"),
+                options=target.get("options")
+            )
+
+        # Convert SCons dependencies to CMake dependencies
+        for target, deps in self.interpreter.dependencies.items():
+            for dep in deps:
+                self.generator.add_dependency(target, dep)
+
+        # Generate CMakeLists.txt
+        self.generator.generate(output_path)

--- a/tools/cmakeconverter/interpreter/core/__init__.py
+++ b/tools/cmakeconverter/interpreter/core/__init__.py
@@ -1,0 +1,4 @@
+"""Mock core module for SCons"""
+from typing import Any, Dict, List, Optional, Union
+
+from . import core_builders

--- a/tools/cmakeconverter/interpreter/core/core_builders.py
+++ b/tools/cmakeconverter/interpreter/core/core_builders.py
@@ -1,0 +1,22 @@
+"""Mock core_builders module for SCons"""
+from typing import Any, Dict, List, Optional, Union
+
+def make_certs_header(target: Any, source: Any, env: Any) -> None:
+    """Build certs header"""
+    pass
+
+def make_authors_header(target: Any, source: Any, env: Any) -> None:
+    """Build authors header"""
+    pass
+
+def make_donors_header(target: Any, source: Any, env: Any) -> None:
+    """Build donors header"""
+    pass
+
+def make_license_header(target: Any, source: Any, env: Any) -> None:
+    """Build license header"""
+    pass
+
+# Make module importable
+import sys
+sys.modules['core.core_builders'] = sys.modules[__name__]

--- a/tools/cmakeconverter/interpreter/detect.py
+++ b/tools/cmakeconverter/interpreter/detect.py
@@ -1,25 +1,42 @@
-"""Mock detect module for platform detection"""
+"""Mock detect module for SCons"""
+from typing import Any, Dict, List, Optional, Union
 
-def get_name():
+def get_name() -> str:
     """Get platform name"""
     return "LinuxBSD"
 
-def can_build():
+def can_build() -> bool:
     """Check if platform can be built"""
     return True
 
-def get_opts():
+def get_opts() -> List[Any]:
     """Get platform options"""
     return []
 
-def get_flags():
-    """Get platform flags"""
+def get_doc_classes() -> List[str]:
+    """Get platform doc classes"""
     return []
 
-def get_doc_classes():
-    """Get platform documentation classes"""
-    return []
-
-def get_doc_path():
-    """Get platform documentation path"""
+def get_doc_path() -> str:
+    """Get platform doc path"""
     return ""
+
+def get_flags() -> Dict[str, Any]:
+    """Get platform flags"""
+    return {}
+
+def configure(env: Any) -> None:
+    """Configure platform"""
+    pass
+
+def get_tools(env: Any) -> List[str]:
+    """Get platform tools"""
+    return []
+
+def get_program_suffix() -> str:
+    """Get program suffix"""
+    return ""
+
+# Make module importable
+import sys
+sys.modules['detect'] = sys.modules[__name__]

--- a/tools/cmakeconverter/interpreter/editor/__init__.py
+++ b/tools/cmakeconverter/interpreter/editor/__init__.py
@@ -1,0 +1,4 @@
+"""Mock editor module for SCons"""
+from typing import Any, Dict, List, Optional, Union
+
+from . import editor_builders

--- a/tools/cmakeconverter/interpreter/editor/editor_builders.py
+++ b/tools/cmakeconverter/interpreter/editor/editor_builders.py
@@ -1,0 +1,30 @@
+"""Mock editor_builders module for SCons"""
+from typing import Any, Dict, List, Optional, Union
+
+def make_doc_header(target: Any, source: Any, env: Any) -> None:
+    """Build doc header"""
+    pass
+
+def make_translations_header(target: Any, source: Any, env: Any, category: str) -> None:
+    """Build translations header"""
+    pass
+
+def make_editor_translations_header(target: Any, source: Any, env: Any) -> None:
+    """Build editor translations header"""
+    pass
+
+def make_property_translations_header(target: Any, source: Any, env: Any) -> None:
+    """Build property translations header"""
+    pass
+
+def make_doc_translations_header(target: Any, source: Any, env: Any) -> None:
+    """Build doc translations header"""
+    pass
+
+def make_extractable_translations_header(target: Any, source: Any, env: Any) -> None:
+    """Build extractable translations header"""
+    pass
+
+# Make module importable
+import sys
+sys.modules['editor.editor_builders'] = sys.modules[__name__]

--- a/tools/cmakeconverter/interpreter/editor/template_builders.py
+++ b/tools/cmakeconverter/interpreter/editor/template_builders.py
@@ -1,0 +1,14 @@
+"""Mock template_builders module for SCons"""
+from typing import Any, Dict, List, Optional, Union
+
+def parse_template(inherits: str, source: str, delimiter: str) -> str:
+    """Parse template"""
+    return ""
+
+def make_templates(target: Any, source: Any, env: Any) -> None:
+    """Build templates"""
+    pass
+
+# Make module importable
+import sys
+sys.modules['editor.template_builders'] = sys.modules[__name__]

--- a/tools/cmakeconverter/interpreter/gles3_builders.py
+++ b/tools/cmakeconverter/interpreter/gles3_builders.py
@@ -1,0 +1,10 @@
+"""Mock gles3_builders module for SCons"""
+from typing import Any, Dict, List, Optional, Union
+
+def build_gles3_headers(target: Any, source: Any, env: Any) -> None:
+    """Build GLES3 headers"""
+    pass
+
+# Make module importable
+import sys
+sys.modules['gles3_builders'] = sys.modules[__name__]

--- a/tools/cmakeconverter/interpreter/glsl_builders.py
+++ b/tools/cmakeconverter/interpreter/glsl_builders.py
@@ -1,0 +1,14 @@
+"""Mock glsl_builders module for SCons"""
+from typing import Any, Dict, List, Optional, Union
+
+def build_rd_headers(target: Any, source: Any, env: Any) -> None:
+    """Build RD headers"""
+    pass
+
+def build_raw_headers(target: Any, source: Any, env: Any) -> None:
+    """Build raw headers"""
+    pass
+
+# Make module importable
+import sys
+sys.modules['glsl_builders'] = sys.modules[__name__]

--- a/tools/cmakeconverter/interpreter/main/__init__.py
+++ b/tools/cmakeconverter/interpreter/main/__init__.py
@@ -1,0 +1,4 @@
+"""Mock main module for SCons"""
+from typing import Any, Dict, List, Optional, Union
+
+from . import main_builders

--- a/tools/cmakeconverter/interpreter/main/main_builders.py
+++ b/tools/cmakeconverter/interpreter/main/main_builders.py
@@ -1,0 +1,18 @@
+"""Mock main_builders module for SCons"""
+from typing import Any, Dict, List, Optional, Union
+
+def make_splash(target: Any, source: Any, env: Any) -> None:
+    """Build splash screen"""
+    pass
+
+def make_splash_editor(target: Any, source: Any, env: Any) -> None:
+    """Build editor splash screen"""
+    pass
+
+def make_app_icon(target: Any, source: Any, env: Any) -> None:
+    """Build app icon"""
+    pass
+
+# Make module importable
+import sys
+sys.modules['main.main_builders'] = sys.modules[__name__]

--- a/tools/cmakeconverter/interpreter/methods.py
+++ b/tools/cmakeconverter/interpreter/methods.py
@@ -1,33 +1,112 @@
-"""Helper methods for SCons interpreter"""
-from contextlib import contextmanager
-import os
-from io import StringIO, TextIOBase
-from typing import Generator, Optional
+"""Mock methods module for SCons"""
+from typing import Any, Dict, List, Optional, Union
 
-@contextmanager
-def generated_wrapper(
-    target,
-    guard: Optional[bool] = None,
-    prefix: str = "",
-    suffix: str = "",
-) -> Generator[TextIOBase, None, None]:
-    """Context manager for generating files"""
-    if isinstance(target, list):
-        target = target[0]
-    if isinstance(target, str):
-        os.makedirs(os.path.dirname(target), exist_ok=True)
-        with open(target, 'w') as f:
-            f.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
-            if guard:
-                guard_name = os.path.basename(target).replace(".", "_").upper()
-                if prefix:
-                    guard_name = prefix + "_" + guard_name
-                if suffix:
-                    guard_name = guard_name + "_" + suffix
-                f.write(f"#ifndef {guard_name}\n")
-                f.write(f"#define {guard_name}\n\n")
-            yield f
-            if guard:
-                f.write(f"\n#endif // {guard_name}\n")
-    else:
-        yield target
+def print_error(message: str) -> None:
+    """Print error message"""
+    print(f"ERROR: {message}")
+
+def print_warning(message: str) -> None:
+    """Print warning message"""
+    print(f"WARNING: {message}")
+
+def print_info(message: str) -> None:
+    """Print info message"""
+    print(f"INFO: {message}")
+
+def to_raw_cstring(value: Union[str, List[str]]) -> str:
+    """Convert to raw C string"""
+    if isinstance(value, list):
+        value = "\n".join(value) + "\n"
+    return f'R"<!>({value})<!>"'
+
+def add_source_files(self: Any, sources: List[Any], files: Union[str, List[str]], allow_gen: bool = False) -> bool:
+    """Add source files"""
+    return True
+
+def add_module_version_string(self: Any, s: str) -> None:
+    """Add module version string"""
+    pass
+
+def get_version_info(module_version_string: str = "", silent: bool = False) -> Dict[str, Any]:
+    """Get version info"""
+    return {}
+
+def get_cmdline_bool(option: str, default: bool) -> bool:
+    """Get command line bool"""
+    return default
+
+def detect_modules(search_path: str, recursive: bool = False) -> Dict[str, str]:
+    """Detect modules"""
+    return {}
+
+def module_add_dependencies(self: Any, module: str, dependencies: List[str], optional: bool = False) -> None:
+    """Add module dependencies"""
+    pass
+
+def module_check_dependencies(self: Any, module: str) -> bool:
+    """Check module dependencies"""
+    return True
+
+def sort_module_list(env: Any) -> None:
+    """Sort module list"""
+    pass
+
+def use_windows_spawn_fix(self: Any, platform: Optional[str] = None) -> None:
+    """Use Windows spawn fix"""
+    pass
+
+def no_verbose(env: Any) -> None:
+    """No verbose"""
+    pass
+
+def prepare_cache(env: Any) -> None:
+    """Prepare cache"""
+    pass
+
+def convert_custom_modules_path(path: str) -> str:
+    """Convert custom modules path"""
+    return path
+
+def set_scu_folders(scu_folders: set) -> None:
+    """Set SCU folders"""
+    pass
+
+def using_gcc(env: Any) -> bool:
+    """Check if using GCC"""
+    return False
+
+def using_clang(env: Any) -> bool:
+    """Check if using Clang"""
+    return False
+
+def using_emcc(env: Any) -> bool:
+    """Check if using Emscripten"""
+    return False
+
+def is_apple_clang(env: Any) -> bool:
+    """Check if using Apple Clang"""
+    return False
+
+def get_compiler_version(env: Any) -> Dict[str, Any]:
+    """Get compiler version"""
+    return {"major": -1, "minor": -1, "metadata1": ""}
+
+def show_progress(env: Any) -> None:
+    """Show progress"""
+    pass
+
+def dump(env: Any) -> None:
+    """Dump environment"""
+    pass
+
+def prepare_purge(env: Any) -> None:
+    """Prepare purge"""
+    pass
+
+def prepare_timer() -> None:
+    """Prepare timer"""
+    pass
+
+# Make module importable
+import sys
+sys.modules['methods'] = sys.modules[__name__]

--- a/tools/cmakeconverter/interpreter/misc/__init__.py
+++ b/tools/cmakeconverter/interpreter/misc/__init__.py
@@ -1,0 +1,4 @@
+"""Mock misc module for SCons"""
+from typing import Any, Dict, List, Optional, Union
+
+from . import utility

--- a/tools/cmakeconverter/interpreter/misc/utility/__init__.py
+++ b/tools/cmakeconverter/interpreter/misc/utility/__init__.py
@@ -1,0 +1,4 @@
+"""Mock utility module for SCons"""
+from typing import Any, Dict, List, Optional, Union
+
+from . import color

--- a/tools/cmakeconverter/interpreter/misc/utility/color.py
+++ b/tools/cmakeconverter/interpreter/misc/utility/color.py
@@ -1,0 +1,40 @@
+"""Mock color module for SCons"""
+from typing import Any, Dict, List, Optional, Union
+
+STDOUT_COLOR = False
+STDERR_COLOR = False
+
+def print_error(*values: object) -> None:
+    """Print error message"""
+    print("ERROR:", *values)
+
+def print_warning(*values: object) -> None:
+    """Print warning message"""
+    print("WARNING:", *values)
+
+def print_info(*values: object) -> None:
+    """Print info message"""
+    print("INFO:", *values)
+
+class Ansi:
+    """Mock Ansi class"""
+    RESET = ""
+    BOLD = ""
+    DIM = ""
+    ITALIC = ""
+    UNDERLINE = ""
+    STRIKETHROUGH = ""
+    REGULAR = ""
+    BLACK = ""
+    RED = ""
+    GREEN = ""
+    YELLOW = ""
+    BLUE = ""
+    MAGENTA = ""
+    CYAN = ""
+    WHITE = ""
+    GRAY = ""
+
+# Make module importable
+import sys
+sys.modules['misc.utility.color'] = sys.modules[__name__]

--- a/tools/cmakeconverter/interpreter/misc/utility/scons_hints.py
+++ b/tools/cmakeconverter/interpreter/misc/utility/scons_hints.py
@@ -1,0 +1,205 @@
+"""Mock scons_hints module for SCons"""
+from typing import Any, Dict, List, Optional, Union
+
+# Global functions
+def GetSConsVersion() -> str:
+    """Get SCons version"""
+    return "4.4.0"
+
+def EnsurePythonVersion(major: int, minor: int) -> None:
+    """Ensure Python version"""
+    pass
+
+def EnsureSConsVersion(major: int, minor: int, revision: int) -> None:
+    """Ensure SCons version"""
+    pass
+
+def Exit(code: int = 0) -> None:
+    """Exit SCons"""
+    pass
+
+def GetLaunchDir() -> str:
+    """Get launch directory"""
+    return "/workspace/godot"
+
+def SConscriptChdir(chdir: bool) -> None:
+    """Set SConscript chdir"""
+    pass
+
+# SConsEnvironment functions
+def Default(*targets: Any) -> None:
+    """Set default targets"""
+    pass
+
+def Export(*vars: Any) -> None:
+    """Export variables"""
+    pass
+
+def Help(text: str) -> None:
+    """Add help text"""
+    pass
+
+def Import(*vars: Any) -> None:
+    """Import variables"""
+    pass
+
+def SConscript(script: str, *args: Any, **kwargs: Any) -> None:
+    """Execute SConscript"""
+    pass
+
+# Environment functions
+def AddPostAction(target: Any, action: Any) -> None:
+    """Add post action"""
+    pass
+
+def AddPreAction(target: Any, action: Any) -> None:
+    """Add pre action"""
+    pass
+
+def Alias(alias: str, targets: Any) -> None:
+    """Create alias"""
+    pass
+
+def AlwaysBuild(*targets: Any) -> None:
+    """Always build targets"""
+    pass
+
+def CacheDir(path: str) -> None:
+    """Set cache directory"""
+    pass
+
+def Clean(target: Any, source: Any) -> None:
+    """Clean target"""
+    pass
+
+def Command(target: Any, source: Any, action: Any) -> None:
+    """Create command"""
+    pass
+
+def Decider(decider: str) -> None:
+    """Set decider"""
+    pass
+
+def Depends(target: Any, dependency: Any) -> None:
+    """Add dependency"""
+    pass
+
+def Dir(path: str) -> Any:
+    """Create directory node"""
+    pass
+
+def Entry(name: str) -> Any:
+    """Create entry node"""
+    pass
+
+def Execute(action: Any) -> None:
+    """Execute action"""
+    pass
+
+def File(path: str) -> Any:
+    """Create file node"""
+    pass
+
+def FindFile(file: str, dirs: Any) -> Any:
+    """Find file"""
+    pass
+
+def FindInstalledFiles() -> List[Any]:
+    """Find installed files"""
+    return []
+
+def FindSourceFiles() -> List[Any]:
+    """Find source files"""
+    return []
+
+def Flatten(sequence: Any) -> List[Any]:
+    """Flatten sequence"""
+    return []
+
+def GetBuildPath(file: str) -> str:
+    """Get build path"""
+    return ""
+
+def Glob(pattern: str) -> List[Any]:
+    """Glob files"""
+    return []
+
+def Ignore(target: Any, dependency: Any) -> None:
+    """Ignore dependency"""
+    pass
+
+def Install(dir: str, source: Any) -> None:
+    """Install source"""
+    pass
+
+def InstallAs(target: str, source: Any) -> None:
+    """Install source as target"""
+    pass
+
+def InstallVersionedLib(target: str, source: Any) -> None:
+    """Install versioned library"""
+    pass
+
+def Literal(string: str) -> Any:
+    """Create literal"""
+    pass
+
+def Local(*targets: Any) -> None:
+    """Mark targets as local"""
+    pass
+
+def NoCache(*targets: Any) -> None:
+    """Disable caching for targets"""
+    pass
+
+def NoClean(*targets: Any) -> None:
+    """Disable cleaning for targets"""
+    pass
+
+def ParseDepends(filename: str) -> None:
+    """Parse dependencies"""
+    pass
+
+def Precious(*targets: Any) -> None:
+    """Mark targets as precious"""
+    pass
+
+def PyPackageDir(package: str) -> str:
+    """Get Python package directory"""
+    return ""
+
+def Repository(*dirs: str) -> None:
+    """Add repository"""
+    pass
+
+def Requires(*targets: Any) -> None:
+    """Add requirements"""
+    pass
+
+def SConsignFile(file: str) -> None:
+    """Set SConsign file"""
+    pass
+
+def SideEffect(side_effect: Any, target: Any) -> None:
+    """Add side effect"""
+    pass
+
+def Split(arg: str) -> List[str]:
+    """Split string"""
+    return []
+
+def Tag(node: Any, tags: Any) -> None:
+    """Add tags"""
+    pass
+
+def Value(value: Any) -> Any:
+    """Create value node"""
+    pass
+
+def VariantDir(variant_dir: str, src_dir: str) -> None:
+    """Create variant directory"""
+    pass
+
+# Make module importable
+import sys
+sys.modules['misc.utility.scons_hints'] = sys.modules[__name__]

--- a/tools/cmakeconverter/interpreter/platform_methods.py
+++ b/tools/cmakeconverter/interpreter/platform_methods.py
@@ -1,0 +1,56 @@
+"""Mock platform_methods module for SCons"""
+from typing import Any, Dict, List, Optional, Union
+
+compatibility_platform_aliases = {
+    "osx": "macos",
+    "iphone": "ios",
+    "x11": "linuxbsd",
+    "javascript": "web",
+}
+
+architectures = ["x86_32", "x86_64", "arm32", "arm64", "rv64", "ppc32", "ppc64", "wasm32", "loongarch64"]
+
+architecture_aliases = {
+    "x86": "x86_32",
+    "x64": "x86_64",
+    "amd64": "x86_64",
+    "armv7": "arm32",
+    "armv8": "arm64",
+    "arm64v8": "arm64",
+    "aarch64": "arm64",
+    "rv": "rv64",
+    "riscv": "rv64",
+    "riscv64": "rv64",
+    "ppcle": "ppc32",
+    "ppc": "ppc32",
+    "ppc64le": "ppc64",
+    "loong64": "loongarch64",
+}
+
+def detect_arch() -> str:
+    """Detect CPU architecture"""
+    return "x86_64"
+
+def validate_arch(arch: str, platform_name: str, supported_arches: List[str]) -> None:
+    """Validate CPU architecture"""
+    pass
+
+def get_build_version(short: bool) -> str:
+    """Get build version"""
+    return "4.4.0"
+
+def lipo(prefix: str, suffix: str) -> str:
+    """Create fat binary"""
+    return ""
+
+def get_mvk_sdk_path(osname: str) -> str:
+    """Get MoltenVK SDK path"""
+    return ""
+
+def detect_mvk(env: Any, osname: str) -> str:
+    """Detect MoltenVK"""
+    return ""
+
+# Make module importable
+import sys
+sys.modules['platform_methods'] = sys.modules[__name__]

--- a/tools/cmakeconverter/interpreter/scu_builders.py
+++ b/tools/cmakeconverter/interpreter/scu_builders.py
@@ -1,0 +1,10 @@
+"""Mock scu_builders module for SCons"""
+from typing import Any, Dict, List, Optional, Union
+
+def generate_scu_files(max_includes_per_scu: int) -> set:
+    """Generate SCU files"""
+    return set()
+
+# Make module importable
+import sys
+sys.modules['scu_builders'] = sys.modules[__name__]

--- a/tools/cmakeconverter/interpreter/version.py
+++ b/tools/cmakeconverter/interpreter/version.py
@@ -1,0 +1,16 @@
+"""Mock version module for SCons"""
+from typing import Any, Dict, List, Optional, Union
+
+short_name = "godot"
+name = "Godot Engine"
+major = 4
+minor = 4
+patch = 0
+status = "beta"
+module_config = ""
+website = "https://godotengine.org"
+docs = "latest"
+
+# Make module importable
+import sys
+sys.modules['version'] = sys.modules[__name__]


### PR DESCRIPTION
This PR adds the initial implementation of the SCons to CMake converter interpreter modules. These modules mock the SCons build system modules to allow parsing the SConstruct file and converting it to CMake.

The following modules have been added:
- `core_builders.py`: Mock core builders module
- `editor_builders.py`: Mock editor builders module
- `template_builders.py`: Mock template builders module
- `gles3_builders.py`: Mock GLES3 builders module
- `platform_methods.py`: Mock platform methods module
- `scu_builders.py`: Mock SCU builders module
- `scons_hints.py`: Mock SCons hints module
- `color.py`: Mock color module

This is still a work in progress and more modules need to be implemented to fully support the conversion.